### PR TITLE
Improve exam upload workflow robustness

### DIFF
--- a/config.js
+++ b/config.js
@@ -34,6 +34,7 @@ const DEFAULT_GRADING_BUTTON_TEXT = 'Grade New Submissions';
 const DEFAULT_APPENDIX_BUTTON_TEXT = 'Upload Appendix';
 const DEFAULT_MODEL_BUTTON_TEXT = 'Upload Answer Model';
 const DEFAULT_SCAN_BUTTON_TEXT = 'Scan Answers';
+const DEFAULT_MULTI_PROCESS_BUTTON_TEXT = 'Process All Submissions';
 const MULTI_SCAN_PAGE_BASE_URL = `${window.location.origin}/multi-scan.html`;
 
 const EDIT_ICON_SVG =

--- a/load-exam-details.js
+++ b/load-exam-details.js
@@ -1,3 +1,192 @@
+let multiUploadUiInitialized = false;
+
+function showSingleStudentForm() {
+  submissionChoiceContainer.classList.add('hidden');
+  studentAnswersForm.classList.remove('hidden');
+  backToSubmissionChoice.classList.remove('hidden');
+}
+
+function resetSingleStudentUploadState() {
+  studentAnswersForm.classList.add('hidden');
+  submissionChoiceContainer.classList.remove('hidden');
+  backToSubmissionChoice.classList.add('hidden');
+
+  if (typeof stopScanPolling === 'function') {
+    stopScanPolling();
+  }
+  studentAnswersForm.reset();
+  scanLinkArea.classList.add('hidden');
+  generateScanLinkButton.disabled = false;
+  setButtonText(generateScanLinkButtonText, DEFAULT_SCAN_BUTTON_TEXT);
+  showSpinner(false, spinnerStudent);
+  if (directUploadInput) {
+    directUploadInput.disabled = false;
+    directUploadInput.value = '';
+  }
+}
+
+function handleMultiUploadModalClick(event) {
+  if (event.target === multiUploadModal) {
+    multiUploadModal.classList.add('hidden');
+    return;
+  }
+
+  if (event.target.closest('.back-to-multi-choice-btn')) {
+    resetMultiUploadState();
+  }
+}
+
+function handleMultiDirectFileLabelChange(event) {
+  if (!event.target.matches('#direct-student-table input[type="file"]')) return;
+
+  const fileInput = event.target;
+  const files = fileInput.files;
+  const label = fileInput.nextElementSibling;
+
+  if (!label) return;
+
+  if (files && files.length > 0) {
+    label.textContent = files.length === 1 ? `1 file` : `${files.length} files`;
+  } else {
+    label.textContent = 'Choose Files';
+  }
+}
+
+function resetMultiUploadState({ preserveSession = false } = {}) {
+  multiUploadChoiceArea.classList.remove('hidden');
+  multiScanArea.classList.add('hidden');
+  multiDirectUploadArea.classList.add('hidden');
+
+  multiScanTableContainer.innerHTML = '';
+  multiDirectUploadTableContainer.innerHTML = '';
+
+  multiScanQrArea.classList.add('hidden');
+  multiScanStartButton.classList.remove('hidden');
+  multiScanStartButton.disabled = false;
+  multiScanAddRowButton.disabled = false;
+
+  multiScanProcessButton.classList.add('hidden');
+  multiScanProcessButton.disabled = false;
+  multiScanProcessButton.onclick = null;
+  showSpinner(false, spinnerMultiProcess);
+  setButtonText(multiScanProcessButtonText, DEFAULT_MULTI_PROCESS_BUTTON_TEXT);
+
+  multiDirectProcessButton.disabled = false;
+  showSpinner(false, spinnerMultiDirectProcess);
+  setButtonText(multiDirectProcessButtonText, DEFAULT_MULTI_PROCESS_BUTTON_TEXT);
+
+  if (!preserveSession) {
+    if (multiScanPollingInterval) clearInterval(multiScanPollingInterval);
+    multiScanPollingInterval = null;
+    currentMultiScanSession = null;
+  }
+}
+
+window.resetMultiUploadState = resetMultiUploadState;
+
+function restoreMultiScanSessionUi() {
+  if (!currentMultiScanSession || !Array.isArray(currentMultiScanSession.students)) {
+    return false;
+  }
+
+  const students = currentMultiScanSession.students;
+  if (students.length === 0) {
+    return false;
+  }
+
+  multiUploadChoiceArea.classList.add('hidden');
+  multiScanArea.classList.remove('hidden');
+
+  generateStudentTable('scan', students.length);
+  const tableRows = document.querySelectorAll('#scan-student-table tbody tr');
+  let allUploaded = true;
+
+  students.forEach((student, index) => {
+    const row = tableRows[index];
+    if (!row) return;
+
+    row.dataset.studentId = student.id || '';
+    const nameInput = row.querySelector('.student-name-input');
+    const numberInput = row.querySelector('.student-number-input');
+    if (nameInput) nameInput.value = student.student_name || '';
+    if (numberInput) numberInput.value = student.student_number || '';
+
+    const statusCell = row.querySelector('.status-cell');
+    if (statusCell) {
+      const status = (student.status || 'pending').toLowerCase();
+      const capitalized = status.charAt(0).toUpperCase() + status.slice(1);
+      statusCell.textContent = capitalized;
+      if (status === 'uploaded') {
+        statusCell.style.color = 'var(--color-green-pastel)';
+        statusCell.style.fontWeight = 'bold';
+      } else {
+        statusCell.style.color = '';
+        statusCell.style.fontWeight = '';
+        allUploaded = false;
+      }
+    }
+  });
+
+  multiScanAddRowButton.disabled = true;
+  multiScanStartButton.classList.add('hidden');
+
+  if (currentMultiScanSession.session_token) {
+    const scanUrl = `${MULTI_SCAN_PAGE_BASE_URL}?token=${currentMultiScanSession.session_token}`;
+    if (typeof QRious === 'function') {
+      new QRious({ element: multiQrcodeCanvas, value: scanUrl, size: 200 });
+    }
+    multiScanUrlLink.href = scanUrl;
+    multiScanUrlLink.textContent = 'Open Link in New Tab';
+    multiScanQrArea.classList.remove('hidden');
+  }
+
+  multiScanProcessButton.onclick = () => handleProcessAllSubmissions('scan');
+  if (allUploaded) {
+    multiScanProcessButton.classList.remove('hidden');
+  } else {
+    multiScanProcessButton.classList.add('hidden');
+  }
+
+  return true;
+}
+
+function setupMultiUploadUi() {
+  if (multiUploadUiInitialized) return;
+
+  multiUploadModal.addEventListener('click', handleMultiUploadModalClick);
+  multiUploadModalClose.addEventListener('click', () => multiUploadModal.classList.add('hidden'));
+  chooseSingleStudentButton.addEventListener('click', showSingleStudentForm);
+  backToSubmissionChoice.addEventListener('click', resetSingleStudentUploadState);
+  chooseMultiStudentButton.addEventListener('click', () => {
+    multiUploadModal.classList.remove('hidden');
+    resetMultiUploadState({ preserveSession: true });
+    if (currentMultiScanSession?.session_token) {
+      restoreMultiScanSessionUi();
+    }
+  });
+  multiScanButton.addEventListener('click', () => {
+    resetMultiUploadState();
+    multiUploadChoiceArea.classList.add('hidden');
+    multiScanArea.classList.remove('hidden');
+    generateStudentTable('scan');
+  });
+  multiDirectUploadButton.addEventListener('click', () => {
+    resetMultiUploadState({ preserveSession: true });
+    multiUploadChoiceArea.classList.add('hidden');
+    multiDirectUploadArea.classList.remove('hidden');
+    generateStudentTable('direct');
+  });
+  multiScanAddRowButton.addEventListener('click', () => addStudentTableRow('scan'));
+  multiDirectAddRowButton.addEventListener('click', () => addStudentTableRow('direct'));
+  multiScanStartButton.addEventListener('click', handleStartMultiScan);
+  multiDirectProcessButton.addEventListener('click', handleProcessAllDirectUploads);
+  multiDirectUploadArea.addEventListener('change', handleMultiDirectFileLabelChange);
+
+  resetMultiUploadState({ preserveSession: true });
+  resetSingleStudentUploadState();
+  multiUploadUiInitialized = true;
+}
+
 /**
  * Load exam details, wire modal and multi-upload events, and render.
  * @param {string} examId
@@ -11,92 +200,7 @@ async function loadExamDetails(examId) {
     return;
   }
 
-  // NEW: Add event listeners for multi-upload modal
-  multiUploadModal.addEventListener('click', (event) => {
-    if (event.target === multiUploadModal) multiUploadModal.classList.add('hidden');
-
-    if (event.target.closest('.back-to-multi-choice-btn')) {
-      multiScanArea.classList.add('hidden');
-      multiDirectUploadArea.classList.add('hidden');
-
-      multiUploadChoiceArea.classList.remove('hidden');
-
-      multiScanTableContainer.innerHTML = '';
-      multiDirectUploadTableContainer.innerHTML = '';
-
-      multiScanQrArea.classList.add('hidden');
-      multiScanStartButton.classList.remove('hidden');
-      multiScanStartButton.disabled = false;
-      multiScanAddRowButton.disabled = false;
-      multiScanProcessButton.classList.add('hidden');
-
-      if (multiScanPollingInterval) clearInterval(multiScanPollingInterval);
-      multiScanPollingInterval = null;
-      currentMultiScanSession = null;
-    }
-  });
-  multiUploadModalClose.addEventListener('click', () => multiUploadModal.classList.add('hidden'));
-
-  chooseSingleStudentButton.addEventListener('click', () => {
-    submissionChoiceContainer.classList.add('hidden');
-    studentAnswersForm.classList.remove('hidden');
-    backToSubmissionChoice.classList.remove('hidden');
-  });
-
-  backToSubmissionChoice.addEventListener('click', () => {
-    studentAnswersForm.classList.add('hidden');
-    submissionChoiceContainer.classList.remove('hidden');
-    backToSubmissionChoice.classList.add('hidden');
-
-    stopScanPolling();
-    studentAnswersForm.reset();
-    scanLinkArea.classList.add('hidden');
-    generateScanLinkButton.disabled = false;
-    setButtonText(generateScanLinkButtonText, DEFAULT_SCAN_BUTTON_TEXT);
-    showSpinner(false, spinnerStudent);
-    if (directUploadInput) {
-      directUploadInput.value = '';
-    }
-  });
-
-    chooseMultiStudentButton.addEventListener('click', () => {
-    multiUploadModal.classList.remove('hidden');
-    multiUploadChoiceArea.classList.remove('hidden');
-    multiScanArea.classList.add('hidden');
-    multiDirectUploadArea.classList.add('hidden');
-  });
-
-  multiScanButton.addEventListener('click', () => {
-    multiUploadChoiceArea.classList.add('hidden');
-    multiScanArea.classList.remove('hidden');
-    generateStudentTable('scan');
-  });
-  multiDirectUploadButton.addEventListener('click', () => {
-    multiUploadChoiceArea.classList.add('hidden');
-    multiDirectUploadArea.classList.remove('hidden');
-    generateStudentTable('direct');
-  });
-
-  multiScanAddRowButton.addEventListener('click', () => addStudentTableRow('scan'));
-  multiDirectAddRowButton.addEventListener('click', () => addStudentTableRow('direct'));
-  multiScanStartButton.addEventListener('click', handleStartMultiScan);
-  multiDirectProcessButton.addEventListener('click', handleProcessAllDirectUploads);
-
-  multiDirectUploadArea.addEventListener('change', (event) => {
-    if (event.target.matches('#direct-student-table input[type="file"]')) {
-      const fileInput = event.target;
-      const files = fileInput.files;
-      const label = fileInput.nextElementSibling;
-
-      if (label) {
-        if (files && files.length > 0) {
-          label.textContent = files.length === 1 ? `1 file` : `${files.length} files`;
-        } else {
-          label.textContent = 'Choose Files';
-        }
-      }
-    }
-  });
+  setupMultiUploadUi();
 
   currentExamData = examData;
   examNameTitle.innerHTML = `
@@ -115,4 +219,7 @@ async function loadExamDetails(examId) {
         refreshStudentView();
     }
 
+  if (!multiUploadModal.classList.contains('hidden') && currentMultiScanSession?.session_token) {
+    restoreMultiScanSessionUi();
+  }
 }


### PR DESCRIPTION
## Summary
- add setup/reset helpers so the multi-upload modal and single-scan form keep consistent state when reopened or cancelled
- introduce shared upload status contexts and sequential processing to avoid cross-workflow UI conflicts and improve feedback
- update multi-scan restoration logic so existing sessions resume cleanly instead of being lost when the modal closes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8a1c4b6f0832e9abb7491c92597e7