### PR TITLE
Handle duplicate students when generating scan sessions

### DIFF
--- a/supabase-edge-functions/generate-scan-session/index.ts
+++ b/supabase-edge-functions/generate-scan-session/index.ts
@@ -57,10 +57,11 @@ serve(async (req) => {
                 .from('students')
                 .select('id')
                 .eq('student_number', normalizedNumber)
-                .maybeSingle();
+                .order('created_at', { ascending: false })
+                .limit(1);
             if (findByNumberError) throw findByNumberError;
-            if (existingByNumber) {
-                studentId = existingByNumber.id;
+            if (existingByNumber && existingByNumber.length > 0) {
+                studentId = existingByNumber[0].id;
             }
         }
         if (!studentId && normalizedName) {
@@ -68,10 +69,11 @@ serve(async (req) => {
                 .from('students')
                 .select('id')
                 .ilike('full_name', normalizedName)
-                .maybeSingle();
+                .order('created_at', { ascending: false })
+                .limit(1);
             if (findByNameError) throw findByNameError;
-            if (existingByName) {
-                studentId = existingByName.id;
+            if (existingByName && existingByName.length > 0) {
+                studentId = existingByName[0].id;
             }
         }
         if (!studentId) {


### PR DESCRIPTION
## Summary
- prevent scan session creation from failing when multiple students share the same name
- select the most recent matching student record when looking up by number or name

## Testing
- not run (Supabase edge function only)


------
https://chatgpt.com/codex/tasks/task_e_68c93300877c832e9a43f295225345e7