### PR TITLE
Add refresh guards and reuse question snapshots

### DIFF
--- a/helpers-fetching.js
+++ b/helpers-fetching.js
@@ -61,7 +61,7 @@ async function fetchExamDataForAppendixJson(examId) {
 async function fetchExamDataForModelJson(examId) {
   return sb
     .from('questions')
-    .select(`question_number, sub_questions (sub_q_text_content)`)
+    .select(`question_number, sub_questions (id, sub_q_text_content)`)
     .eq('exam_id', examId)
     .order('question_number', { ascending: true });
 }

--- a/load-exam-details.js
+++ b/load-exam-details.js
@@ -1,11 +1,17 @@
 let examUiInitialized = false;
+let latestLoadExamRequestId = 0;
 
 /**
  * Load exam details, wire modal and multi-upload events, and render.
  * @param {string} examId
  */
 async function loadExamDetails(examId) {
+  const requestId = ++latestLoadExamRequestId;
   const { data: examData, error } = await fetchFullExamDetails(examId);
+
+  if (requestId !== latestLoadExamRequestId) {
+    return;
+  }
 
   if (error) {
     examNameTitle.textContent = 'Error Loading Exam';


### PR DESCRIPTION
## Summary
- snapshot exam questions once during scan/model processing and reuse the mapping instead of refetching mid-flight
- add editing-aware refresh helpers and defer exam reloads from scan, multi-scan, and appendix/model uploads until edits finish
- guard loadExamDetails with a monotonically increasing request id to ignore stale responses

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c9f126d528832e8b791120185e0677