### PR TITLE
Guard exam refresh while editing and reuse cached question snapshots

### DIFF
--- a/multi-scan-upload.js
+++ b/multi-scan-upload.js
@@ -448,7 +448,18 @@ async function handleProcessAllSubmissions(type) {
         } else {
             setMultiDirectProcessState({ buttonText: 'All processed! Refreshing...', spinner: false, disabled: true, status: 'success' });
         }
-        await loadExamDetails(examId);
+        if (window.isEditSessionActive && window.isEditSessionActive()) {
+            if (typeof window.queueExamRefresh === 'function') {
+                window.queueExamRefresh(examId, { source: type === 'scan' ? 'multi-scan-session' : 'multi-direct-upload' });
+            }
+            if (type === 'scan') {
+                setMultiScanProcessState({ buttonText: 'All processed! Finish edits to refresh.', spinner: false, disabled: true, visible: true, status: 'success' });
+            } else {
+                setMultiDirectProcessState({ buttonText: 'All processed! Finish edits to refresh.', spinner: false, disabled: true, status: 'success' });
+            }
+        } else {
+            await loadExamDetails(examId);
+        }
         setTimeout(() => multiUploadModal.classList.add('hidden'), 2000);
     } catch (error) {
         console.error('Error during multi-submission processing:', error);


### PR DESCRIPTION
## Summary
- cache the exam question structure before invoking scan/model background workers and reuse the snapshot when saving results
- add a shared inline-edit session tracker that exposes helper APIs and queues refreshes until editing is finished
- guard exam reloads with a monotonically increasing token and deferred refresh handling so uploads do not clobber in-progress edits

## Testing
- Not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cb392c9240832eb39afa3ddcfbf397