### PR TITLE
Guard exam refreshes during uploads and editing

### DIFF
--- a/appendix-model-upload.js
+++ b/appendix-model-upload.js
@@ -35,9 +35,6 @@ window.applyAppendixUploadState = applyAppendixUploadState;
 // --- APPENDIX UPLOAD LOGIC (MODIFIED LOGGING) ---
 appendixForm.addEventListener('submit', async (e) => {
   e.preventDefault();
-  if (typeof window.requireEditsUnlocked === 'function' && !window.requireEditsUnlocked()) {
-    return;
-  }
   if (appendixResetTimeout) {
     clearTimeout(appendixResetTimeout);
     appendixResetTimeout = null;
@@ -168,9 +165,6 @@ function prepareModelExamSnapshot(questions = []) {
 // --- ANSWER MODEL UPLOAD LOGIC (MODIFIED LOGGING) ---
 modelForm.addEventListener('submit', async (e) => {
   e.preventDefault();
-  if (typeof window.requireEditsUnlocked === 'function' && !window.requireEditsUnlocked()) {
-    return;
-  }
   if (modelResetTimeout) {
     clearTimeout(modelResetTimeout);
     modelResetTimeout = null;

--- a/appendix-model-upload.js
+++ b/appendix-model-upload.js
@@ -85,7 +85,11 @@ appendixForm.addEventListener('submit', async (e) => {
     setAppendixUploadState({ buttonText: 'Refreshing data...' });
     appendixForm.reset();
     document.getElementById('appendix-file-display').textContent = 'No files chosen';
-    await loadExamDetails(examId);
+    if (typeof window.enqueueExamRefresh === 'function' && window.isEditSessionActive?.()) {
+      await window.enqueueExamRefresh(() => loadExamDetails(examId));
+    } else {
+      await loadExamDetails(examId);
+    }
   } catch (error) {
     setAppendixUploadState({ status: 'error', buttonText: 'Error!', spinner: false });
     console.error(error);
@@ -134,6 +138,27 @@ function scheduleModelReset(delayMs) {
 applyModelUploadState();
 window.applyModelUploadState = applyModelUploadState;
 
+function prepareModelExamSnapshot(questions = []) {
+  const subQuestionLookup = {};
+  const sanitizedQuestions = questions.map((question) => {
+    const sanitizedSubQuestions = (question.sub_questions || []).map((subQuestion) => {
+      if (subQuestion?.id) {
+        if (!subQuestionLookup[question.question_number]) {
+          subQuestionLookup[question.question_number] = {};
+        }
+        subQuestionLookup[question.question_number][subQuestion.sub_q_text_content] = subQuestion.id;
+      }
+      return { sub_q_text_content: subQuestion.sub_q_text_content };
+    });
+    return {
+      question_number: question.question_number,
+      sub_questions: sanitizedSubQuestions,
+    };
+  });
+
+  return { subQuestionLookup, sanitizedQuestions };
+}
+
 // --- ANSWER MODEL UPLOAD LOGIC (MODIFIED LOGGING) ---
 modelForm.addEventListener('submit', async (e) => {
   e.preventDefault();
@@ -158,7 +183,8 @@ modelForm.addEventListener('submit', async (e) => {
     setModelUploadState({ buttonText: 'Fetching exam...' });
     const { data: examStructure, error: fetchError } = await fetchExamDataForModelJson(examId);
     if (fetchError) throw new Error(`Could not fetch exam data for model: ${fetchError.message}`);
-    const examStructureForGcf = { questions: examStructure };
+    const { subQuestionLookup, sanitizedQuestions } = prepareModelExamSnapshot(examStructure || []);
+    const examStructureForGcf = { questions: sanitizedQuestions };
 
     setModelUploadState({ buttonText: 'Thinking... (~4 mins)' });
     const formData = new FormData();
@@ -182,12 +208,16 @@ modelForm.addEventListener('submit', async (e) => {
     const modelData = JSON.parse(jsonContent);
 
     setModelUploadState({ buttonText: 'Saving...' });
-    await processAndUploadModel(examId, modelData.questions, zip);
+    await processAndUploadModel(examId, modelData.questions, zip, subQuestionLookup);
 
     setModelUploadState({ buttonText: 'Refreshing data...' });
     modelForm.reset();
     document.getElementById('model-file-display').textContent = 'No files chosen';
-    await loadExamDetails(examId);
+    if (typeof window.enqueueExamRefresh === 'function' && window.isEditSessionActive?.()) {
+      await window.enqueueExamRefresh(() => loadExamDetails(examId));
+    } else {
+      await loadExamDetails(examId);
+    }
   } catch (error) {
     setModelUploadState({ status: 'error', buttonText: 'Error!', spinner: false });
     console.error(error);
@@ -271,7 +301,7 @@ async function processAndUploadAppendices(examId, appendices, zip) {
  * @param {Array<any>} modelQuestions
  * @param {JSZip} zip
  */
-async function processAndUploadModel(examId, modelQuestions, zip) {
+async function processAndUploadModel(examId, modelQuestions, zip, precomputedLookup = null) {
   setModelUploadState({ buttonText: 'Processing rules...' });
   const rulesFile = zip.file('grading_rules.txt');
   if (rulesFile) {
@@ -290,18 +320,21 @@ async function processAndUploadModel(examId, modelQuestions, zip) {
     }
   }
 
-  const { data: dbQuestions, error: fetchError } = await sb
-    .from('questions')
-    .select('id, question_number, sub_questions(id, sub_q_text_content)')
-    .eq('exam_id', examId);
-  if (fetchError) throw new Error(`Could not fetch exam structure for matching: ${fetchError.message}`);
-  const subQuestionLookup = dbQuestions.reduce((qMap, q) => {
-    qMap[q.question_number] = q.sub_questions.reduce((sqMap, sq) => {
-      sqMap[sq.sub_q_text_content] = sq.id;
-      return sqMap;
+  let subQuestionLookup = precomputedLookup;
+  if (!subQuestionLookup) {
+    const { data: dbQuestions, error: fetchError } = await sb
+      .from('questions')
+      .select('id, question_number, sub_questions(id, sub_q_text_content)')
+      .eq('exam_id', examId);
+    if (fetchError) throw new Error(`Could not fetch exam structure for matching: ${fetchError.message}`);
+    subQuestionLookup = dbQuestions.reduce((qMap, q) => {
+      qMap[q.question_number] = q.sub_questions.reduce((sqMap, sq) => {
+        sqMap[sq.sub_q_text_content] = sq.id;
+        return sqMap;
+      }, {});
+      return qMap;
     }, {});
-    return qMap;
-  }, {});
+  }
 
   for (const q_model of modelQuestions) {
     for (const sq_model of q_model.sub_questions) {

--- a/delete-handlers.js
+++ b/delete-handlers.js
@@ -112,6 +112,61 @@
         return wrap;
     }
 
+    function requestExamRefresh(examId) {
+        if (!examId) return Promise.resolve();
+        const editingActive = typeof window.isEditSessionActive === 'function' && window.isEditSessionActive();
+        if (editingActive && typeof window.enqueueExamRefresh === 'function') {
+            return window.enqueueExamRefresh(() => loadExamDetails(examId));
+        }
+        return loadExamDetails(examId);
+    }
+
+    function removeQuestionDom(questionId) {
+        if (!Q_CONTAINER || !questionId) return;
+        const block = Q_CONTAINER.querySelector(`.question-block[data-question-id="${questionId}"]`);
+        if (block) {
+            block.remove();
+        }
+    }
+
+    function removeSubQuestionDom(subQuestionId) {
+        if (!Q_CONTAINER || !subQuestionId) return;
+        const subCell = Q_CONTAINER.querySelector(`#sub-q-gridcell.grid-cell[data-sub-question-id="${subQuestionId}"]`);
+        if (!subCell) return;
+        const modelCell = subCell.nextElementSibling;
+        const studentCell = modelCell?.nextElementSibling;
+        const questionBlock = subCell.closest('.question-block');
+        subCell.remove();
+        if (modelCell) modelCell.remove();
+        if (studentCell) studentCell.remove();
+        const addBtn = questionBlock?.querySelector('.add-subq-btn');
+        if (addBtn) addBtn.classList.remove('hidden');
+    }
+
+    function removeModelAlternativeDom(alternativeId) {
+        if (!Q_CONTAINER || !alternativeId) return;
+        const alt = Q_CONTAINER.querySelector(`.model-alternative[data-alternative-id="${alternativeId}"]`);
+        if (!alt) return;
+        const section = alt.closest('.model-answer-section');
+        const parentCell = alt.closest('.grid-cell');
+        alt.remove();
+        if (section && !section.querySelector('.model-alternative')) {
+            const placeholder = section.querySelector('.no-model-placeholder');
+            if (placeholder) placeholder.classList.remove('hidden');
+        }
+        if (parentCell) {
+            const addAltBtn = parentCell.querySelector('.add-model-alt-btn');
+            if (addAltBtn) addAltBtn.classList.remove('hidden');
+        }
+    }
+
+    function removeStudentSubmissionDom(studentId) {
+        if (!Q_CONTAINER || !studentId) return;
+        Q_CONTAINER.querySelectorAll(`.student-answer-dropdown[data-student-id="${studentId}"]`).forEach((details) => {
+            details.remove();
+        });
+    }
+
     // Inject delete buttons where needed (idempotent)
     function injectDeleteButtons() {
         if (!Q_CONTAINER) return;
@@ -281,7 +336,8 @@
                 if (!confirmed) return;
                 const { error } = await sb.rpc('delete_question_cascade', { p_question_id: id });
                 if (error) throw error;
-                await loadExamDetails(examId);
+                removeQuestionDom(id);
+                await requestExamRefresh(examId);
                 return;
             }
 
@@ -295,7 +351,8 @@
                 if (!confirmed) return;
                 const { error } = await sb.rpc('delete_sub_question_cascade', { p_sub_question_id: id });
                 if (error) throw error;
-                await loadExamDetails(examId);
+                removeSubQuestionDom(id);
+                await requestExamRefresh(examId);
                 return;
             }
 
@@ -309,7 +366,8 @@
                 if (!confirmed) return;
                 const { error } = await sb.rpc('delete_model_alternative_cascade', { p_alternative_id: id });
                 if (error) throw error;
-                await loadExamDetails(examId);
+                removeModelAlternativeDom(id);
+                await requestExamRefresh(examId);
                 return;
             }
 
@@ -344,7 +402,8 @@
                     p_student_id: studentId,
                 });
                 if (error) throw error;
-                await loadExamDetails(examId);
+                removeStudentSubmissionDom(studentId);
+                await requestExamRefresh(examId);
                 return;
             }
 

--- a/delete-handlers.js
+++ b/delete-handlers.js
@@ -114,10 +114,6 @@
 
     function requestExamRefresh(examId) {
         if (!examId) return Promise.resolve();
-        const editingActive = typeof window.isEditSessionActive === 'function' && window.isEditSessionActive();
-        if (editingActive && typeof window.enqueueExamRefresh === 'function') {
-            return window.enqueueExamRefresh(() => loadExamDetails(examId));
-        }
         return loadExamDetails(examId);
     }
 
@@ -326,6 +322,11 @@
         const ptsDel = e.target.closest('.points-delete-btn');
 
         try {
+            const attemptedDelete = qDel || sqDel || altDel || compDel || stuDel || ptsDel;
+            if (attemptedDelete && typeof window.requireEditsUnlocked === 'function' && !window.requireEditsUnlocked()) {
+                return;
+            }
+
             if (qDel) {
                 const id = qDel.dataset.questionId;
                 if (!id) return;

--- a/editing.js
+++ b/editing.js
@@ -98,14 +98,22 @@ function applyStudentDetailsUpdates({ studentId = null, token = null, answersDat
         const nameEl = details.querySelector('[data-editable="full_name"]');
         if (nameEl && normalizedName !== undefined) {
             setOriginalTextDataset(nameEl, normalizedName);
-            nameEl.textContent = normalizedName;
+            if (nameEl.querySelector('.editable-input')) {
+                stagePendingDisplay(nameEl, 'full_name', normalizedName);
+            } else {
+                nameEl.textContent = normalizedName;
+            }
         }
 
         const numberEl = details.querySelector('[data-editable="student_number"]');
         if (numberEl && normalizedNumber !== undefined) {
             setOriginalTextDataset(numberEl, normalizedNumber);
             const displayNumber = normalizedNumber || 'No number';
-            numberEl.textContent = displayNumber;
+            if (numberEl.querySelector('.editable-input')) {
+                stagePendingDisplay(numberEl, 'student_number', displayNumber);
+            } else {
+                numberEl.textContent = displayNumber;
+            }
         }
 
         const subId = findSubQuestionIdForStudentDetails(details);
@@ -134,6 +142,11 @@ function applyStudentDetailsUpdates({ studentId = null, token = null, answersDat
                 editBtn.dataset.answerId = String(answerRow.id);
             }
         }
+
+        // Remove any static placeholder text nodes we injected during staging
+        answerItem.querySelectorAll(':scope > p.formatted-text:not([data-editable])').forEach((placeholder) => {
+            placeholder.remove();
+        });
 
         let answerTextEl = answerItem.querySelector('[data-editable="answer_text"]');
         if (!answerTextEl) {

--- a/exam.html
+++ b/exam.html
@@ -233,6 +233,18 @@
         </div>
     </div>
 
+    <div id="editing-locked-modal" class="modal-overlay hidden">
+        <div class="modal-content confirm-modal-content">
+            <span class="modal-close" id="editing-locked-modal-close">×</span>
+            <h3>Action Unavailable</h3>
+            <p id="editing-locked-modal-text">Uploads or score generation are currently in progress. Please wait until they finish before editing, deleting, or adding items.</p>
+            <div class="confirm-modal-actions">
+                <button id="editing-locked-modal-close-btn" class="cancel-btn">Close</button>
+                <button id="editing-locked-modal-understood-btn" class="save-btn">Understood</button>
+            </div>
+        </div>
+    </div>
+
     <div id="confirm-modal" class="modal-overlay hidden">
         <div class="modal-content confirm-modal-content">
             <span class="modal-close" id="confirm-modal-close">×</span>

--- a/grading.js
+++ b/grading.js
@@ -3,9 +3,6 @@
 // --- AUTOMATIC GRADING LOGIC (REFACTORED) ---
 gradeAllButton.addEventListener('click', async (e) => {
   e.preventDefault();
-  if (typeof window.requireEditsUnlocked === 'function' && !window.requireEditsUnlocked()) {
-    return;
-  }
   gradeAllButton.disabled = true;
   showSpinner(true, spinnerGrading);
   updateGradingButtonText('Starting...');

--- a/grading.js
+++ b/grading.js
@@ -3,6 +3,9 @@
 // --- AUTOMATIC GRADING LOGIC (REFACTORED) ---
 gradeAllButton.addEventListener('click', async (e) => {
   e.preventDefault();
+  if (typeof window.requireEditsUnlocked === 'function' && !window.requireEditsUnlocked()) {
+    return;
+  }
   gradeAllButton.disabled = true;
   showSpinner(true, spinnerGrading);
   updateGradingButtonText('Starting...');
@@ -11,8 +14,12 @@ gradeAllButton.addEventListener('click', async (e) => {
   const examId = urlParams.get('id');
   let finalMessage = '';
   let isError = false;
+  let lockKey = null;
 
   try {
+    if (typeof window.enterProcessingLock === 'function') {
+      lockKey = window.enterProcessingLock('grading');
+    }
     updateGradingButtonText('Finding submissions...');
     
     // START OF CHANGE: Switched from checking points to checking status
@@ -55,6 +62,9 @@ gradeAllButton.addEventListener('click', async (e) => {
     finalMessage = `Critical Error. See console.`;
     isError = true;
   } finally {
+    if (typeof window.exitProcessingLock === 'function') {
+      window.exitProcessingLock(lockKey);
+    }
     updateGradingButtonText(finalMessage);
     showSpinner(false, spinnerGrading);
 

--- a/helpers-fetching.js
+++ b/helpers-fetching.js
@@ -61,7 +61,7 @@ async function fetchExamDataForAppendixJson(examId) {
 async function fetchExamDataForModelJson(examId) {
   return sb
     .from('questions')
-    .select(`question_number, sub_questions (sub_q_text_content)`)
+    .select(`question_number, sub_questions (id, sub_q_text_content)`)
     .eq('exam_id', examId)
     .order('question_number', { ascending: true });
 }

--- a/load-exam-details.js
+++ b/load-exam-details.js
@@ -5,13 +5,7 @@ let loadExamDetailsRequestToken = 0;
  * Load exam details, wire modal and multi-upload events, and render.
  * @param {string} examId
  */
-async function loadExamDetails(examId, { bypassQueue = false } = {}) {
-  if (!bypassQueue && typeof window.isEditSessionActive === 'function' && window.isEditSessionActive()) {
-    if (typeof window.enqueueExamRefresh === 'function') {
-      return window.enqueueExamRefresh(() => loadExamDetails(examId, { bypassQueue: true }));
-    }
-  }
-
+async function loadExamDetails(examId) {
   const requestToken = ++loadExamDetailsRequestToken;
   const { data: examData, error } = await fetchFullExamDetails(examId);
 
@@ -23,12 +17,6 @@ async function loadExamDetails(examId, { bypassQueue = false } = {}) {
     examNameTitle.textContent = 'Error Loading Exam';
     questionsContainer.innerHTML = `<p>Could not load exam details: ${error.message}</p>`;
     return;
-  }
-
-  if (typeof window.isEditSessionActive === 'function' && window.isEditSessionActive()) {
-    if (typeof window.enqueueExamRefresh === 'function') {
-      return window.enqueueExamRefresh(() => loadExamDetails(examId, { bypassQueue: true }));
-    }
   }
 
   if (!examUiInitialized) {

--- a/main.js
+++ b/main.js
@@ -59,11 +59,17 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (!btn) return;
 
         if (btn.classList.contains('add-subq-btn')) {
+            if (typeof window.requireEditsUnlocked === 'function' && !window.requireEditsUnlocked()) {
+                return;
+            }
             const qId = btn.dataset.questionId || btn.closest('.question-block')?.dataset?.questionId;
             if (qId) stageNewSubQuestion(qId);
         }
 
         if (btn.classList.contains('add-model-alt-btn')) {
+            if (typeof window.requireEditsUnlocked === 'function' && !window.requireEditsUnlocked()) {
+                return;
+            }
             const subQId = btn.dataset.subQuestionId
                 || btn.closest('.grid-cell')?.dataset?.subQuestionId
                 || '';
@@ -71,11 +77,17 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
 
         if (btn.classList.contains('add-student-btn')) {
+            if (typeof window.requireEditsUnlocked === 'function' && !window.requireEditsUnlocked()) {
+                return;
+            }
             const examId = btn.dataset.examId;
             if (examId) stageNewStudent(examId, btn);
         }
 
         if (btn.classList.contains('add-question-btn')) {
+            if (typeof window.requireEditsUnlocked === 'function' && !window.requireEditsUnlocked()) {
+                return;
+            }
             const examId = btn.dataset.examId;
             if (examId) stageNewQuestion(examId);
         }

--- a/multi-scan-upload.js
+++ b/multi-scan-upload.js
@@ -393,7 +393,12 @@ async function handleProcessAllDirectUploads() {
  * @param {'scan'|'direct'} type
  */
 async function handleProcessAllSubmissions(type) {
-  let isError = false; // Add a flag to track success/failure
+  if (typeof window.requireEditsUnlocked === 'function' && !window.requireEditsUnlocked()) {
+    return;
+  }
+
+  let isError = false;
+  let lockKey = null;
 
   if (type === 'scan') {
     setMultiScanProcessState({ status: 'processing', visible: true, disabled: true, spinner: true, buttonText: 'Processing...' });
@@ -432,44 +437,51 @@ async function handleProcessAllSubmissions(type) {
     return;
   }
 
-    try {
-        if (type === 'scan') {
-            setMultiScanProcessState({ buttonText: `Processing ${submissions.length} submissions (~4 mins)...`, spinner: true });
-        } else {
-            setMultiDirectProcessState({ buttonText: `Processing ${submissions.length} submissions (~4 mins)...`, spinner: true });
-        }
-        const processingPromises = submissions.map((sub) => processSingleSubmission(examId, sub, type));
-        await Promise.all(processingPromises);
-
-        if (type === 'scan') {
-            setMultiScanProcessState({ buttonText: 'All processed! Refreshing...', spinner: false, disabled: true, visible: true, status: 'success' });
-            currentMultiScanSession = null;
-            resetMultiScanSessionState();
-        } else {
-            setMultiDirectProcessState({ buttonText: 'All processed! Refreshing...', spinner: false, disabled: true, status: 'success' });
-        }
-        if (typeof window.enqueueExamRefresh === 'function' && window.isEditSessionActive?.()) {
-            await window.enqueueExamRefresh(() => loadExamDetails(examId));
-        } else {
-            await loadExamDetails(examId);
-        }
-        setTimeout(() => multiUploadModal.classList.add('hidden'), 2000);
-    } catch (error) {
-        console.error('Error during multi-submission processing:', error);
-        if (type === 'scan') {
-            setMultiScanProcessState({ status: 'error', buttonText: 'Error! See console.', spinner: false, disabled: true, visible: true });
-        } else {
-            setMultiDirectProcessState({ status: 'error', buttonText: 'Error! See console.', spinner: false, disabled: true });
-        }
-        isError = true; // Set flag on error
-    } finally {
-        if (type === 'scan') {
-            scheduleMultiScanProcessReset(isError ? 10000 : 5000);
-        } else {
-            scheduleMultiDirectProcessReset(isError ? 10000 : 5000);
-        }
+  try {
+    if (typeof window.enterProcessingLock === 'function') {
+      lockKey = window.enterProcessingLock(type === 'scan' ? 'multi-scan-upload' : 'multi-direct-upload');
     }
+
+    if (type === 'scan') {
+      setMultiScanProcessState({ buttonText: `Processing ${submissions.length} submissions (~4 mins)...`, spinner: true });
+    } else {
+      setMultiDirectProcessState({ buttonText: `Processing ${submissions.length} submissions (~4 mins)...`, spinner: true });
+    }
+
+    const processingPromises = submissions.map((sub) => processSingleSubmission(examId, sub, type));
+    await Promise.all(processingPromises);
+
+    if (type === 'scan') {
+      setMultiScanProcessState({ buttonText: 'All processed! Refreshing...', spinner: false, disabled: true, visible: true, status: 'success' });
+      currentMultiScanSession = null;
+      resetMultiScanSessionState();
+    } else {
+      setMultiDirectProcessState({ buttonText: 'All processed! Refreshing...', spinner: false, disabled: true, status: 'success' });
+    }
+
+    await loadExamDetails(examId);
+    setTimeout(() => multiUploadModal.classList.add('hidden'), 2000);
+  } catch (error) {
+    console.error('Error during multi-submission processing:', error);
+    if (type === 'scan') {
+      setMultiScanProcessState({ status: 'error', buttonText: 'Error! See console.', spinner: false, disabled: true, visible: true });
+    } else {
+      setMultiDirectProcessState({ status: 'error', buttonText: 'Error! See console.', spinner: false, disabled: true });
+    }
+    isError = true; // Set flag on error
+  } finally {
+    if (typeof window.exitProcessingLock === 'function') {
+      window.exitProcessingLock(lockKey);
+    }
+
+    if (type === 'scan') {
+      scheduleMultiScanProcessReset(isError ? 10000 : 5000);
+    } else {
+      scheduleMultiDirectProcessReset(isError ? 10000 : 5000);
+    }
+  }
 }
+
 
 /**
  * Process a single submission for multi-upload (scan/direct).

--- a/multi-scan-upload.js
+++ b/multi-scan-upload.js
@@ -448,7 +448,11 @@ async function handleProcessAllSubmissions(type) {
         } else {
             setMultiDirectProcessState({ buttonText: 'All processed! Refreshing...', spinner: false, disabled: true, status: 'success' });
         }
-        await loadExamDetails(examId);
+        if (typeof window.enqueueExamRefresh === 'function' && window.isEditSessionActive?.()) {
+            await window.enqueueExamRefresh(() => loadExamDetails(examId));
+        } else {
+            await loadExamDetails(examId);
+        }
         setTimeout(() => multiUploadModal.classList.add('hidden'), 2000);
     } catch (error) {
         console.error('Error during multi-submission processing:', error);

--- a/multi-scan-upload.js
+++ b/multi-scan-upload.js
@@ -393,10 +393,6 @@ async function handleProcessAllDirectUploads() {
  * @param {'scan'|'direct'} type
  */
 async function handleProcessAllSubmissions(type) {
-  if (typeof window.requireEditsUnlocked === 'function' && !window.requireEditsUnlocked()) {
-    return;
-  }
-
   let isError = false;
   let lockKey = null;
 

--- a/render-exam.js
+++ b/render-exam.js
@@ -165,7 +165,7 @@ function renderExam(questions) {
             const urlParams = new URLSearchParams(window.location.search);
             const examId = urlParams.get('id');
             const studentCell = `
-        <div id="student-answer-gridcell" class="grid-cell">
+        <div id="student-answer-gridcell" class="grid-cell" data-sub-question-id="${sq.id}">
           ${studentAnswersHtml}
           <button class="add-student-btn add-row-btn" data-exam-id="${examId}">Add New Student Submission</button>
         </div>`;
@@ -383,7 +383,10 @@ function stageNewStudent(examId, originButton) {
     const token = _randToken();
 
     // Hide ONLY the button in the grid-cell where user clicked
-    if (originButton) originButton.classList.add('hidden');
+    if (originButton) {
+        originButton.classList.add('hidden');
+        originButton.dataset.newStudentToken = token;
+    }
 
     // We target student cells by looking for cells that contain the .add-student-btn
     const studentCells = questionsContainer.querySelectorAll('.sub-question-grid .grid-cell');
@@ -395,6 +398,16 @@ function stageNewStudent(examId, originButton) {
         const wrapper = document.createElement('details');
         wrapper.className = 'student-answer-dropdown';
         wrapper.dataset.newStudentToken = token;
+
+        let subId = cell.dataset.subQuestionId || null;
+        if (!subId) {
+            const modelCell = cell.previousElementSibling || null;
+            const subCell = modelCell ? modelCell.previousElementSibling : null;
+            const candidate = subCell && subCell.dataset ? subCell.dataset.subQuestionId : null;
+            if (candidate) subId = candidate;
+        }
+        if (subId) wrapper.dataset.subQuestionId = subId;
+
         wrapper.open = true;
         wrapper.innerHTML = `
       <summary>
@@ -489,7 +502,7 @@ function stageNewModelAlternative(subQuestionId) {
 
 /** Stage a new empty question block and enter edit for its context */
 function stageNewQuestion(examId) {
-    // Compute “next” question number from current DOM
+    // Compute Â“nextÂ” question number from current DOM
     const existingNums = Array.from(
         questionsContainer.querySelectorAll('.question-header .question-title-wrapper span')
     )

--- a/scan-single.js
+++ b/scan-single.js
@@ -114,6 +114,27 @@ window.applySingleScanState = applySingleScanState;
 window.cancelSingleScanSession = cancelSingleScanSession;
 window.getSingleScanState = () => ({ ...singleScanState });
 
+function prepareExamSnapshot(questions = []) {
+  const subQuestionLookup = {};
+  const sanitizedQuestions = questions.map((question) => {
+    const safeSubQuestions = (question.sub_questions || []).map((subQuestion) => {
+      if (subQuestion?.id) {
+        if (!subQuestionLookup[question.question_number]) {
+          subQuestionLookup[question.question_number] = {};
+        }
+        subQuestionLookup[question.question_number][subQuestion.sub_q_text_content] = subQuestion.id;
+      }
+      return { sub_q_text_content: subQuestion.sub_q_text_content };
+    });
+    return {
+      question_number: question.question_number,
+      sub_questions: safeSubQuestions,
+    };
+  });
+
+  return { subQuestionLookup, sanitizedQuestions };
+}
+
 // --- STUDENT SCAN LINK GENERATION (MODIFIED LOGGING) ---
 generateScanLinkButton.addEventListener('click', async () => {
   clearSingleScanResetTimer();
@@ -358,12 +379,13 @@ async function processScannedAnswersBackground(scanSession, examId, progressCb =
     progressCb('Fetching exam...');
     const { data: examStructure, error: fetchExamError } = await sb
       .from('questions')
-      .select(`question_number, sub_questions(sub_q_text_content)`)
+      .select(`question_number, sub_questions(id, sub_q_text_content)`)
       .eq('exam_id', examId)
       .order('question_number', { ascending: true });
 
     if (fetchExamError) throw fetchExamError;
-    const examStructureForGcf = { questions: examStructure };
+    const { subQuestionLookup, sanitizedQuestions } = prepareExamSnapshot(examStructure || []);
+    const examStructureForGcf = { questions: sanitizedQuestions };
 
     progressCb('Downloading images...');
     const formData = new FormData();
@@ -425,7 +447,7 @@ async function processScannedAnswersBackground(scanSession, examId, progressCb =
       const responseData = JSON.parse(jsonContent);
 
       progressCb('Saving answers...');
-      await saveStudentAnswersFromScan(scanSession, examId, responseData, zip, progressCb);
+      await saveStudentAnswersFromScan(scanSession, examId, responseData, zip, progressCb, subQuestionLookup);
 
       await sb.from('scan_sessions').update({ status: 'completed' }).eq('id', scanSession.id);
       cleanupTempFiles(scanSession);
@@ -494,7 +516,11 @@ async function processScannedAnswers(examId, preloadedSession = null) {
       setSingleScanState({ status: 'success', buttonText: 'Processed!', spinner: false });
     }
 
-    await loadExamDetails(examId);
+    if (typeof window.enqueueExamRefresh === 'function' && window.isEditSessionActive?.()) {
+      await window.enqueueExamRefresh(() => loadExamDetails(examId));
+    } else {
+      await loadExamDetails(examId);
+    }
   } catch (error) {
     console.error('Error processing scanned session:', error.message);
     setSingleScanState({ status: 'error', buttonText: 'Error!', spinner: false });
@@ -514,7 +540,14 @@ async function processScannedAnswers(examId, preloadedSession = null) {
  * @param {any} responseData
  * @param {JSZip} zip
  */
-async function saveStudentAnswersFromScan(scanSession, examId, responseData, zip, progressCb = () => {}) {
+async function saveStudentAnswersFromScan(
+  scanSession,
+  examId,
+  responseData,
+  zip,
+  progressCb = () => {},
+  precomputedLookup = null,
+) {
   const studentExamId = scanSession.student_exam_id;
 
   if (!studentExamId) {
@@ -532,19 +565,22 @@ async function saveStudentAnswersFromScan(scanSession, examId, responseData, zip
     processedData = responseData[0];
   }
 
-  const { data: dbQuestions, error: fetchQError } = await sb
-    .from('questions')
-    .select('id, question_number, sub_questions(id, sub_q_text_content)')
-    .eq('exam_id', examId);
-  if (fetchQError) throw new Error(`Could not fetch exam structure for matching: ${fetchQError.message}`);
+  let subQuestionLookup = precomputedLookup;
+  if (!subQuestionLookup) {
+    const { data: dbQuestions, error: fetchQError } = await sb
+      .from('questions')
+      .select('id, question_number, sub_questions(id, sub_q_text_content)')
+      .eq('exam_id', examId);
+    if (fetchQError) throw new Error(`Could not fetch exam structure for matching: ${fetchQError.message}`);
 
-  const subQuestionLookup = dbQuestions.reduce((qMap, q) => {
-    qMap[q.question_number] = q.sub_questions.reduce((sqMap, sq) => {
-      sqMap[sq.sub_q_text_content] = sq.id;
-      return sqMap;
+    subQuestionLookup = dbQuestions.reduce((qMap, q) => {
+      qMap[q.question_number] = q.sub_questions.reduce((sqMap, sq) => {
+        sqMap[sq.sub_q_text_content] = sq.id;
+        return sqMap;
+      }, {});
+      return qMap;
     }, {});
-    return qMap;
-  }, {});
+  }
 
   const answersToInsert = [];
   if (!processedData || !processedData.questions || !Array.isArray(processedData.questions)) {


### PR DESCRIPTION
## Summary
- snapshot exam structures before scan/model uploads and reuse the cached sub-question map while saving results
- coordinate exam reloads with a monotonic request token plus new edit-session helpers to queue refreshes during inline edits
- surface edit-session state globally so uploads defer renders until editing ends and inline saves exit edit mode immediately with updated text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb41b0f990832eb6513ecb23a17dd8