### PR TITLE
Always create new student records for scan and submission sessions

### DIFF
--- a/supabase-edge-functions/create-submission-session/index.ts
+++ b/supabase-edge-functions/create-submission-session/index.ts
@@ -37,28 +37,12 @@ serve(async (req) => {
         }
         const supabaseClient = createClient(Deno.env.get('SUPABASE_URL') ?? '', Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '');
         // --- This logic is already correct for finding/creating student and student_exam ---
-        let studentId;
-        let existingStudent = null;
-        if (studentNumber && studentNumber.trim() !== '') {
-            const { data, error } = await supabaseClient.from('students').select('id').eq('student_number', studentNumber).maybeSingle();
-            if (error) throw new Error(`Error finding student by number: ${error.message}`);
-            existingStudent = data;
-        }
-        if (!existingStudent && studentName && studentName.trim() !== '') {
-            const { data, error } = await supabaseClient.from('students').select('id').eq('full_name', studentName).maybeSingle();
-            if (error) throw new Error(`Error finding student by name: ${error.message}`);
-            existingStudent = data;
-        }
-        if (existingStudent) {
-            studentId = existingStudent.id;
-        } else {
-            const { data: newStudent, error: createError } = await supabaseClient.from('students').insert({
-                full_name: studentName || null,
-                student_number: studentNumber || null
-            }).select('id').single();
-            if (createError) throw new Error(`Error creating new student: ${createError.message}`);
-            studentId = newStudent.id;
-        }
+        const { data: newStudent, error: createError } = await supabaseClient.from('students').insert({
+            full_name: studentName || null,
+            student_number: studentNumber || null
+        }).select('id').single();
+        if (createError) throw new Error(`Error creating new student: ${createError.message}`);
+        const studentId = newStudent.id;
         let studentExamId;
         const { data: existingStudentExam, error: findError } = await supabaseClient.from('student_exams').select('id').eq('student_id', studentId).eq('exam_id', examId).maybeSingle();
         if (findError) throw findError;

--- a/supabase-edge-functions/generate-scan-session/index.ts
+++ b/supabase-edge-functions/generate-scan-session/index.ts
@@ -50,44 +50,16 @@ serve(async (req) => {
         }
         const supabaseClient = createClient(Deno.env.get('SUPABASE_URL') ?? '', Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '');
         // --- START: ROBUST STUDENT & STUDENT_EXAM CREATION ---
-        let studentId = null;
-        // Find or create student
-        if (normalizedNumber) {
-            const { data: existingByNumber, error: findByNumberError } = await supabaseClient
-                .from('students')
-                .select('id')
-                .eq('student_number', normalizedNumber)
-                .order('created_at', { ascending: false })
-                .limit(1);
-            if (findByNumberError) throw findByNumberError;
-            if (existingByNumber && existingByNumber.length > 0) {
-                studentId = existingByNumber[0].id;
-            }
-        }
-        if (!studentId && normalizedName) {
-            const { data: existingByName, error: findByNameError } = await supabaseClient
-                .from('students')
-                .select('id')
-                .ilike('full_name', normalizedName)
-                .order('created_at', { ascending: false })
-                .limit(1);
-            if (findByNameError) throw findByNameError;
-            if (existingByName && existingByName.length > 0) {
-                studentId = existingByName[0].id;
-            }
-        }
-        if (!studentId) {
-            const { data: newStudent, error: createStudentError } = await supabaseClient
-                .from('students')
-                .insert({
-                    full_name: normalizedName || null,
-                    student_number: normalizedNumber || null
-                })
-                .select('id')
-                .single();
-            if (createStudentError) throw createStudentError;
-            studentId = newStudent.id;
-        }
+        const { data: newStudent, error: createStudentError } = await supabaseClient
+            .from('students')
+            .insert({
+                full_name: normalizedName || null,
+                student_number: normalizedNumber || null
+            })
+            .select('id')
+            .single();
+        if (createStudentError) throw createStudentError;
+        const studentId = newStudent.id;
         // Find or create the student_exam record to get its ID
         let studentExamId;
         const { data: existingStudentExam, error: findError } = await supabaseClient.from('student_exams').select('id').eq('student_id', studentId).eq('exam_id', examId).maybeSingle();

--- a/supabase-sql-functions/find_or_create_student.sql
+++ b/supabase-sql-functions/find_or_create_student.sql
@@ -7,17 +7,9 @@ AS $$
 DECLARE
     v_student_id uuid;
 BEGIN
-    SELECT s.id INTO v_student_id
-    FROM public.students s
-    WHERE (p_student_number IS NOT NULL AND s.student_number = p_student_number)
-       OR (p_full_name IS NOT NULL AND s.full_name = p_full_name)
-    LIMIT 1;
-
-    IF v_student_id IS NULL THEN
-        INSERT INTO public.students (full_name, student_number)
-        VALUES (p_full_name, p_student_number)
-        RETURNING students.id INTO v_student_id;
-    END IF;
+    INSERT INTO public.students (full_name, student_number)
+    VALUES (p_full_name, p_student_number)
+    RETURNING students.id INTO v_student_id;
 
     RETURN QUERY SELECT v_student_id;
 END;


### PR DESCRIPTION
## Summary
- always insert a new student record in the generate scan session edge function before linking to student_exams
- mirror the same insert-first behavior in the create submission session edge function
- update the SQL helper to unconditionally insert a new student record

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ceec0e3128832e8ef88fcd3ce96629