### PR TITLE
Add exam deletion controls and cascade cleanup

### DIFF
--- a/delete-handlers.js
+++ b/delete-handlers.js
@@ -329,6 +329,7 @@
         const examId = examIdFromUrl();
         if (!examId) return;
 
+        const examDel = e.target.closest('#delete-exam-button');
         const qDel = e.target.closest('.question-delete-btn');
         const sqDel = e.target.closest('.sub-q-delete-btn');
         const altDel = e.target.closest('.model-alt-delete-btn');
@@ -337,6 +338,28 @@
         const ptsDel = e.target.closest('.points-delete-btn');
 
         try {
+            if (examDel) {
+                const titleEl = document.getElementById('exam-name-title');
+                const examName = titleEl?.textContent?.trim();
+                const confirmed = await showConfirmModal(
+                    `Delete the entire exam${examName ? ` "${examName}"` : ''} and all of its questions, student submissions, and scans? This cannot be undone.`,
+                    'Delete Exam',
+                );
+                if (!confirmed) return;
+
+                examDel.disabled = true;
+                try {
+                    const { error } = await sb.rpc('delete_exam_cascade', { p_exam_id: examId });
+                    if (error) throw error;
+                    window.location.href = 'index.html';
+                } catch (deleteError) {
+                    console.error('Failed to delete exam:', deleteError);
+                    alert('Failed to delete the exam. Please try again.');
+                    examDel.disabled = false;
+                }
+                return;
+            }
+
             const attemptedDelete = qDel || sqDel || altDel || compDel || stuDel || ptsDel;
             if (attemptedDelete && typeof window.requireEditsUnlocked === 'function' && !window.requireEditsUnlocked()) {
                 return;

--- a/exam.html
+++ b/exam.html
@@ -46,6 +46,7 @@
 
                 <button id="show-rules-button" class="hidden">Show Grading Regulations</button>
                 <button id="show-grades-button" class="hidden pushable-button">Show Points</button>
+                <button id="delete-exam-button" type="button">Delete Exam</button>
             </div>
         </div>
     </div>

--- a/index.css
+++ b/index.css
@@ -232,12 +232,17 @@ button {
 }
 
 .exam-card {
-    display: block;
+    position: relative;
     padding: 1.5rem;
     border-radius: 15px;
-    text-decoration: none;
     background-color: var(--color-light-blue-two);
     transition-duration: 0.3s;
+}
+
+.exam-card-link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
 }
 
     .exam-card:hover {
@@ -254,5 +259,138 @@ button {
         margin: 0;
         font-size: 0.9rem;
         color: #666;
+    }
+
+.exam-delete-btn {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    border: none;
+    background: transparent;
+    padding: 5px;
+    border-radius: 10px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.3s;
+}
+
+    .exam-delete-btn:hover,
+    .exam-delete-btn:focus-visible {
+        background-color: var(--color-light-blue-two);
+        outline: none;
+    }
+
+.exam-delete-btn svg {
+    width: 24px;
+    height: 24px;
+    stroke: transparent;
+    transition: stroke 0.3s;
+}
+
+    .exam-card:hover .exam-delete-btn svg,
+    .exam-delete-btn:focus-visible svg {
+        stroke: var(--color-text-dark);
+    }
+
+/* Modal styles (matching exam page) */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    z-index: 1000;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 1rem;
+}
+
+.modal-content {
+    background: var(--color-background);
+    padding: 2rem 2rem 0 2rem;
+    border-radius: 25px;
+    width: 90%;
+    max-width: 450px;
+    position: relative;
+    max-height: 85vh;
+    overflow-y: auto;
+    text-align: center;
+}
+
+.modal-close {
+    position: absolute;
+    top: 10px;
+    right: 20px;
+    font-size: 2rem;
+    font-weight: bold;
+    color: var(--color-text-dark);
+    cursor: pointer;
+    line-height: 1;
+    background: none;
+    border: none;
+    padding: 0;
+}
+
+    .modal-close:hover {
+        color: var(--color-danger);
+    }
+
+.confirm-modal-content h3 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    font-size: 1.5rem;
+}
+
+.confirm-modal-content p {
+    margin-bottom: 2rem;
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
+.confirm-modal-actions {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+}
+
+.save-btn,
+.cancel-btn {
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+    border-radius: 10px;
+    border: none;
+    cursor: pointer;
+    transition: 0.3s ease;
+    font-weight: bold;
+}
+
+.cancel-btn {
+    background-color: var(--color-lighter-blue);
+    color: var(--color-text-dark);
+}
+
+    .cancel-btn:hover {
+        background-color: var(--color-light-blue-two);
+    }
+
+.save-btn {
+    background-color: var(--color-green-pastel-light-one);
+    color: var(--color-text-light);
+}
+
+    .save-btn:hover {
+        filter: brightness(113%);
+    }
+
+.save-btn.danger {
+    background-color: var(--color-danger);
+}
+
+    .save-btn.danger:hover {
+        filter: brightness(110%);
     }
 

--- a/index.html
+++ b/index.html
@@ -51,6 +51,18 @@
         </div>
     </div>
 
+    <div id="confirm-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="confirm-modal-title">
+        <div class="modal-content confirm-modal-content">
+            <button type="button" class="modal-close" id="confirm-modal-close" aria-label="Close confirmation dialog">×</button>
+            <h3 id="confirm-modal-title">Confirm Action</h3>
+            <p id="confirm-modal-text">Are you sure?</p>
+            <div class="confirm-modal-actions">
+                <button type="button" id="confirm-modal-cancel-btn" class="cancel-btn">Cancel</button>
+                <button type="button" id="confirm-modal-confirm-btn" class="save-btn danger">Confirm</button>
+            </div>
+        </div>
+    </div>
+
 </body>
 <script src="index.js"></script>
 </html>

--- a/scan-and-title.css
+++ b/scan-and-title.css
@@ -23,6 +23,23 @@
     align-items: center; /* This ensures buttons align with the title */
 }
 
+#delete-exam-button {
+    background: var(--color-danger-between);
+    color: var(--color-text-light);
+    border: 3px solid var(--color-danger-light);
+    box-shadow: -4px 8px 0 var(--color-danger);
+    transform: translateY(-3px) translateX(0);
+    padding: 0.6rem 1.1rem;
+    width: fit-content;
+    margin-left: 20px;
+    font-weight: 800;
+}
+
+    #delete-exam-button:hover {
+        transform: translateY(0) translateX(-2px);
+        box-shadow: -2px 4px 0 var(--color-danger);
+    }
+
 #title-wrapper-left,
 #title-wrapper-right {
     display: flex;


### PR DESCRIPTION
## Summary
- add trashcan delete controls to exam cards on the index page with a shared confirmation modal
- expose a top-right Delete Exam button inside the exam view that reuses the confirmation flow and redirects after removal
- create a delete_exam_cascade Supabase function to remove related sessions, submissions, and questions before deleting the exam

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf159ea9e0832eb8d9ed75c4ba3bec