### PR TITLE
Add Gemini streaming follow-up assistant for feedback

### DIFF
--- a/api/gemini-key.js
+++ b/api/gemini-key.js
@@ -1,0 +1,36 @@
+const resolveGeminiApiKey = () => {
+  const {
+    GEMINI_API_KEY = '',
+    NEXT_PUBLIC_GEMINI_API_KEY = '',
+    VERCEL_GEMINI_API_KEY = '',
+  } = process.env || {};
+
+  return GEMINI_API_KEY || NEXT_PUBLIC_GEMINI_API_KEY || VERCEL_GEMINI_API_KEY || '';
+};
+
+module.exports = (req, res) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.statusCode = 405;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Method Not Allowed' }));
+    return;
+  }
+
+  const apiKey = resolveGeminiApiKey();
+  if (!apiKey) {
+    res.statusCode = 404;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'GEMINI_API_KEY not configured' }));
+    return;
+  }
+
+  res.setHeader('Cache-Control', 'no-store');
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(
+    JSON.stringify({
+      geminiApiKey: apiKey,
+    })
+  );
+};

--- a/config.js
+++ b/config.js
@@ -9,6 +9,12 @@ const GRADING_GCF_URL = 'https://generate-points-232485517114.europe-west1.run.a
 const BULK_BOUNDARY_GCF_URL = 'https://bulk-submission-boundaries-232485517114.europe-west1.run.app';
 const STORAGE_BUCKET = 'exam-visuals';
 
+// Gemini API (set GEMINI_API_KEY before using streaming follow-ups)
+const GEMINI_API_KEY = (typeof window !== 'undefined'
+  && (window.__GEMINI_API_KEY__ || window.GEMINI_API_KEY))
+  ? String(window.__GEMINI_API_KEY__ || window.GEMINI_API_KEY)
+  : '';
+
 // --- NEW: Supabase Edge Function URLs ---
 const GENERATE_SCAN_SESSION_URL = `${SUPABASE_URL}/functions/v1/generate-scan-session`;
 const PROCESS_SCANNED_SESSION_URL = `${SUPABASE_URL}/functions/v1/process-scanned-session`;

--- a/config.js
+++ b/config.js
@@ -10,10 +10,38 @@ const BULK_BOUNDARY_GCF_URL = 'https://bulk-submission-boundaries-232485517114.e
 const STORAGE_BUCKET = 'exam-visuals';
 
 // Gemini API (set GEMINI_API_KEY before using streaming follow-ups)
-const GEMINI_API_KEY = (typeof window !== 'undefined'
-  && (window.__GEMINI_API_KEY__ || window.GEMINI_API_KEY))
-  ? String(window.__GEMINI_API_KEY__ || window.GEMINI_API_KEY)
-  : '';
+const GEMINI_API_KEY = (() => {
+  if (typeof window !== 'undefined') {
+    const fromWindow = window.__GEMINI_API_KEY__ || window.GEMINI_API_KEY;
+    if (fromWindow) {
+      return String(fromWindow);
+    }
+  }
+
+  if (typeof globalThis !== 'undefined') {
+    const fromGlobal = globalThis.__GEMINI_API_KEY__;
+    if (fromGlobal) {
+      return String(fromGlobal);
+    }
+  }
+
+  if (typeof process !== 'undefined' && process.env) {
+    const {
+      GEMINI_API_KEY: envKey,
+      NEXT_PUBLIC_GEMINI_API_KEY: nextPublicKey,
+      VERCEL_GEMINI_API_KEY: vercelKey,
+    } = process.env;
+    const resolved = envKey || nextPublicKey || vercelKey;
+    if (resolved) {
+      if (typeof window !== 'undefined') {
+        window.__GEMINI_API_KEY__ = resolved;
+      }
+      return String(resolved);
+    }
+  }
+
+  return '';
+})();
 
 // --- NEW: Supabase Edge Function URLs ---
 const GENERATE_SCAN_SESSION_URL = `${SUPABASE_URL}/functions/v1/generate-scan-session`;

--- a/exam.html
+++ b/exam.html
@@ -298,6 +298,7 @@
 <script src="editing-mode.js"></script>
 <script src="delete-handlers.js"></script>
 <script src="render-exam.js"></script>
+<script src="feedback-followup.js"></script>
 <script src="student-view.js"></script>
 <script src="appendix-model-upload.js"></script>
 <script src="grading.js"></script>

--- a/feedback-followup.js
+++ b/feedback-followup.js
@@ -116,9 +116,28 @@ const GEMINI_STREAM_URL =
     const question = textarea.value.trim();
     if (!question) return;
 
-    const apiKey = typeof GEMINI_API_KEY === 'string' ? GEMINI_API_KEY.trim() : '';
+    setStatus(statusEl, 'Preparing Gemini…');
+
+    let apiKey = '';
+    try {
+      const loader =
+        (typeof globalThis !== 'undefined' && typeof globalThis.ensureGeminiApiKey === 'function')
+          ? globalThis.ensureGeminiApiKey
+          : null;
+
+      if (loader) {
+        apiKey = await loader();
+      } else if (typeof GEMINI_API_KEY === 'string') {
+        apiKey = GEMINI_API_KEY.trim();
+      }
+    } catch (error) {
+      console.error('Failed to load the Gemini API key.', error);
+      setStatus(statusEl, 'Gemini follow-ups are temporarily unavailable.', { isError: true });
+      return;
+    }
+
     if (!apiKey) {
-      setStatus(statusEl, 'Set GEMINI_API_KEY in config.js to enable Gemini follow-ups.', { isError: true });
+      setStatus(statusEl, 'Gemini follow-ups are not configured yet.', { isError: true });
       return;
     }
 

--- a/feedback-followup.js
+++ b/feedback-followup.js
@@ -1,5 +1,5 @@
-const GEMINI_STREAM_URL =
-  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse';
+const GEMINI_STREAM_BASE_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:streamGenerateContent';
 
 (function () {
   const conversations = new Map();
@@ -187,6 +187,13 @@ const GEMINI_STREAM_URL =
     }
   }
 
+  function buildGeminiStreamUrl(apiKey) {
+    const url = new URL(GEMINI_STREAM_BASE_URL);
+    url.searchParams.set('alt', 'sse');
+    url.searchParams.set('key', apiKey);
+    return url.toString();
+  }
+
   async function streamGeminiResponse(conversation, apiKey, onStream) {
     const requestBody = {
       contents: conversation.messages.map((message) => ({
@@ -201,11 +208,10 @@ const GEMINI_STREAM_URL =
       };
     }
 
-    const response = await fetch(GEMINI_STREAM_URL, {
+    const response = await fetch(buildGeminiStreamUrl(apiKey), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-goog-api-key': apiKey,
       },
       body: JSON.stringify(requestBody),
     });

--- a/feedback-followup.js
+++ b/feedback-followup.js
@@ -193,7 +193,8 @@ const GEMINI_STREAM_URL =
         role: message.role,
         parts: message.parts.map((part) => ({ text: part.text })),
       })),
-      system_instruction: {
+      systemInstruction: {
+        role: 'system',
         parts: [{ text: conversation.systemInstruction }],
       },
     };

--- a/feedback-followup.js
+++ b/feedback-followup.js
@@ -1,0 +1,248 @@
+const GEMINI_STREAM_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse';
+
+(function () {
+  const conversations = new Map();
+
+  function hydrate() {
+    document.querySelectorAll('.feedback-followup').forEach(initializeBlock);
+  }
+
+  function initializeBlock(block) {
+    if (!block || block.dataset.initialized === 'true') return;
+    block.dataset.initialized = 'true';
+
+    const answerId = block.dataset.answerId;
+    if (!answerId) return;
+
+    const contextText = block.dataset.context ? decodeURIComponent(block.dataset.context) : '';
+    const questionLabel = block.dataset.questionLabel ? decodeURIComponent(block.dataset.questionLabel) : '';
+    const subLabel = block.dataset.subLabel ? decodeURIComponent(block.dataset.subLabel) : '';
+
+    const contextLabelEl = block.querySelector('.followup-context-label');
+    if (contextLabelEl) {
+      contextLabelEl.textContent = '';
+      if (questionLabel) {
+        const strong = document.createElement('strong');
+        strong.textContent = questionLabel;
+        contextLabelEl.appendChild(strong);
+      }
+      if (questionLabel && subLabel) {
+        contextLabelEl.append(' · ');
+      }
+      if (subLabel) {
+        contextLabelEl.append(subLabel);
+      }
+    }
+
+    const textarea = block.querySelector('.followup-input');
+    const sendBtn = block.querySelector('.followup-send-btn');
+    const historyEl = block.querySelector('.followup-history');
+    const statusEl = block.querySelector('.followup-status');
+
+    if (!textarea || !sendBtn || !historyEl || !statusEl) return;
+
+    if (!conversations.has(answerId)) {
+      conversations.set(answerId, {
+        messages: [],
+        systemInstruction: buildSystemInstruction(contextText),
+      });
+    }
+
+    sendBtn.addEventListener('click', () => {
+      submitFollowup(answerId, {
+        block,
+        textarea,
+        sendBtn,
+        historyEl,
+        statusEl,
+      });
+    });
+
+    textarea.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        submitFollowup(answerId, {
+          block,
+          textarea,
+          sendBtn,
+          historyEl,
+          statusEl,
+        });
+      }
+    });
+  }
+
+  function buildSystemInstruction(contextText) {
+    const baseInstruction = [
+      'You are a thoughtful AI teaching assistant who explains grading decisions.',
+      'Base every answer strictly on the provided grading context.',
+      'If information is missing, clearly say so instead of guessing.',
+      'Use numbered or bulleted lists when outlining rubric items or reasoning steps.',
+      'Keep the tone encouraging and student-friendly.',
+    ].join(' ');
+
+    if (!contextText) {
+      return baseInstruction;
+    }
+
+    return `${baseInstruction}\n\nGrading context:\n${contextText}`;
+  }
+
+  function appendHistoryMessage(historyEl, role, text, { isStreaming = false } = {}) {
+    const wrapper = document.createElement('div');
+    wrapper.className = `followup-message followup-message-${role}`;
+    if (isStreaming) {
+      wrapper.classList.add('is-streaming');
+    }
+
+    const bubble = document.createElement('div');
+    bubble.className = 'followup-bubble';
+    bubble.textContent = text;
+    wrapper.appendChild(bubble);
+
+    historyEl.appendChild(wrapper);
+    historyEl.scrollTop = historyEl.scrollHeight;
+    return bubble;
+  }
+
+  function setStatus(statusEl, message, { isError = false } = {}) {
+    statusEl.textContent = message || '';
+    statusEl.classList.toggle('is-error', Boolean(isError));
+  }
+
+  async function submitFollowup(answerId, ui) {
+    const { block, textarea, sendBtn, historyEl, statusEl } = ui;
+    const question = textarea.value.trim();
+    if (!question) return;
+
+    const apiKey = typeof GEMINI_API_KEY === 'string' ? GEMINI_API_KEY.trim() : '';
+    if (!apiKey) {
+      setStatus(statusEl, 'Set GEMINI_API_KEY in config.js to enable Gemini follow-ups.', { isError: true });
+      return;
+    }
+
+    const conversation = conversations.get(answerId);
+    if (!conversation) return;
+
+    setStatus(statusEl, 'Gemini is thinking…');
+    appendHistoryMessage(historyEl, 'user', question);
+
+    textarea.value = '';
+    textarea.blur();
+
+    const streamingBubble = appendHistoryMessage(historyEl, 'model', '', { isStreaming: true });
+    sendBtn.disabled = true;
+    textarea.disabled = true;
+    block.classList.add('is-streaming');
+
+    conversation.messages.push({
+      role: 'user',
+      parts: [{ text: question }],
+    });
+
+    try {
+      const fullText = await streamGeminiResponse(conversation, apiKey, (partial) => {
+        streamingBubble.textContent = partial;
+        historyEl.scrollTop = historyEl.scrollHeight;
+      });
+
+      streamingBubble.textContent = fullText;
+      streamingBubble.parentElement.classList.remove('is-streaming');
+      conversation.messages.push({
+        role: 'model',
+        parts: [{ text: fullText }],
+      });
+      setStatus(statusEl, 'Response ready.');
+    } catch (error) {
+      streamingBubble.parentElement.classList.add('is-error');
+      streamingBubble.textContent = error.message || 'Unable to generate a response.';
+      conversation.messages.pop();
+      setStatus(statusEl, 'Gemini could not reply.', { isError: true });
+    } finally {
+      sendBtn.disabled = false;
+      textarea.disabled = false;
+      block.classList.remove('is-streaming');
+      textarea.focus();
+      setTimeout(() => setStatus(statusEl, ''), 4000);
+    }
+  }
+
+  async function streamGeminiResponse(conversation, apiKey, onStream) {
+    const requestBody = {
+      contents: conversation.messages.map((message) => ({
+        role: message.role,
+        parts: message.parts.map((part) => ({ text: part.text })),
+      })),
+      system_instruction: {
+        parts: [{ text: conversation.systemInstruction }],
+      },
+    };
+
+    const response = await fetch(GEMINI_STREAM_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': apiKey,
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    if (!response.ok || !response.body) {
+      throw new Error(`Gemini request failed (${response.status} ${response.statusText}).`);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let fullText = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      const events = buffer.split('\n\n');
+      buffer = events.pop() || '';
+
+      for (const event of events) {
+        const dataPayload = event
+          .split('\n')
+          .filter((line) => line.startsWith('data:'))
+          .map((line) => line.slice(5))
+          .join('');
+
+        if (!dataPayload) continue;
+        const trimmed = dataPayload.trim();
+        if (!trimmed || trimmed === '[DONE]') continue;
+
+        let parsed;
+        try {
+          parsed = JSON.parse(trimmed);
+        } catch (error) {
+          console.warn('Unable to parse Gemini stream chunk', error);
+          continue;
+        }
+
+        const textChunk = (parsed?.candidates?.[0]?.content?.parts || [])
+          .map((part) => part?.text || '')
+          .join('');
+
+        if (!textChunk) continue;
+
+        fullText += textChunk;
+        onStream(fullText);
+      }
+    }
+
+    if (!fullText) {
+      throw new Error('Gemini returned an empty response.');
+    }
+
+    return fullText.trim();
+  }
+
+  window.followupSupport = {
+    hydrate,
+  };
+})();

--- a/render-exam.js
+++ b/render-exam.js
@@ -1,3 +1,76 @@
+function createFollowupContext(examData, question, subQuestion, answer) {
+    if (!examData || !question || !subQuestion || !answer) return null;
+
+    const modelExpectationLines = [];
+    (subQuestion.model_alternatives || []).forEach((alt, altIndex) => {
+        const altLabel = `Alternative ${alt?.alternative_number ?? altIndex + 1}`;
+        const altNotes = alt?.extra_comment ? ` — ${alt.extra_comment}` : '';
+        modelExpectationLines.push(`${altLabel}${altNotes}`.trim());
+        (alt?.model_components || [])
+            .sort((a, b) => {
+                const ao = Number.isFinite(+a?.component_order) ? +a.component_order : Number.MAX_SAFE_INTEGER;
+                const bo = Number.isFinite(+b?.component_order) ? +b.component_order : Number.MAX_SAFE_INTEGER;
+                return ao - bo;
+            })
+            .forEach((comp, compIndex) => {
+                const points = (comp?.component_points ?? comp?.orig_llm_component_points);
+                const label = comp?.component_text || comp?.orig_llm_component_text || `Component ${compIndex + 1}`;
+                const pointLabel = Number.isFinite(Number(points)) ? ` (${points} pts)` : '';
+                modelExpectationLines.push(`  • ${label}${pointLabel}`.trim());
+            });
+    });
+
+    const studentText = answer.answer_text
+        ? answer.answer_text.replace(/\\n/g, '\n')
+        : (answer.orig_llm_answer_text ? answer.orig_llm_answer_text.replace(/\\n/g, '\n') : '');
+
+    const awardedPoints = (answer.sub_points_awarded ?? answer.orig_llm_sub_points_awarded);
+    const gradedPoints = Number.isFinite(Number(awardedPoints)) ? Number(awardedPoints) : null;
+    const maxPoints = subQuestion.max_sub_points ?? '?';
+
+    const contextSections = [
+        `Exam: ${examData.exam_name || 'Untitled Exam'}`,
+    ];
+
+    if (examData.grading_regulations) {
+        contextSections.push(`Grading regulations: ${examData.grading_regulations}`);
+    }
+
+    if (question.context_text) {
+        contextSections.push(`Question context: ${question.context_text}`);
+    }
+
+    if (subQuestion.sub_q_text_content) {
+        contextSections.push(`Prompt: ${subQuestion.sub_q_text_content}`);
+    }
+
+    if (modelExpectationLines.length > 0) {
+        contextSections.push(`Answer expectations:\n${modelExpectationLines.join('\n')}`);
+    }
+
+    if (studentText) {
+        contextSections.push(`Student answer (text):\n${studentText}`);
+    }
+
+    if (answer.answer_visual) {
+        contextSections.push(`Student answer visual URL: ${answer.answer_visual}`);
+    }
+
+    contextSections.push(
+        `Points awarded: ${gradedPoints !== null ? gradedPoints : 'Not awarded'} out of ${maxPoints}`,
+    );
+
+    if (answer.feedback_comment) {
+        contextSections.push(`Original feedback: ${answer.feedback_comment}`);
+    }
+
+    return {
+        contextText: contextSections.join('\n\n'),
+        questionLabel: `Question ${question.question_number || ''}`,
+        subQuestionLabel: subQuestion.sub_q_text_content || '',
+    };
+}
+
 /**
  * Render the exam questions, appendices, models, and student answers.
  * Also renders add-buttons:
@@ -139,6 +212,26 @@ function renderExam(questions) {
                         const feedbackHtml = ans.feedback_comment
                             ? `<div class="feedback-comment formatted-text" data-editable="feedback_comment" data-original-text="${ans.feedback_comment || ''}">${ans.feedback_comment}</div>`
                             : '';
+                        const followupMeta = createFollowupContext(currentExamData, q, sq, ans);
+                        const followupHtml = (ans.sub_points_awarded !== null || ans.feedback_comment)
+                            ? `<div class="feedback-followup" data-answer-id="${ans.id}"
+                                   data-context="${followupMeta ? encodeURIComponent(followupMeta.contextText) : ''}"
+                                   data-question-label="${followupMeta ? encodeURIComponent(followupMeta.questionLabel) : ''}"
+                                   data-sub-label="${followupMeta ? encodeURIComponent(followupMeta.subQuestionLabel) : ''}">
+                                  <div class="followup-header">
+                                    <span class="followup-title">Need more insight on this score?</span>
+                                    <span class="followup-status" aria-live="polite"></span>
+                                  </div>
+                                  <p class="followup-context-label"></p>
+                                  <div class="followup-history" aria-live="polite"></div>
+                                  <label class="followup-label" for="followup-input-${ans.id}">Ask a follow-up question</label>
+                                  <div class="followup-input-row">
+                                    <textarea id="followup-input-${ans.id}" class="followup-input" rows="2" placeholder="Ask about the feedback or awarded points..."></textarea>
+                                    <button type="button" class="followup-send-btn" data-answer-id="${ans.id}">Ask Gemini</button>
+                                  </div>
+                                  <p class="followup-footnote">Powered by Gemini 2.5 Pro</p>
+                                </div>`
+                            : '';
                         return `
               <div class="student-answer-item" data-answer-id="${ans.id}">
                 <button id="student-answer-edit-btn" class="edit-btn" data-edit-target="student_answer" data-answer-id="${ans.id}">${EDIT_ICON_SVG}</button>
@@ -146,6 +239,7 @@ function renderExam(questions) {
                 ${ans.answer_visual ? `<img src="${ans.answer_visual}" alt="Student answer visual" class="student-answer-visual">` : ''}
                 ${pointsHtml}
                 ${feedbackHtml}
+                ${followupHtml}
               </div>
             `;
                     }).join('');
@@ -259,6 +353,10 @@ function renderExam(questions) {
         ],
         throwOnError: false,
     });
+
+    if (window.followupSupport && typeof window.followupSupport.hydrate === 'function') {
+        window.followupSupport.hydrate();
+    }
 }
 
 /* ====== STAGING HELPERS (invoked by main.js event delegation) ====== */

--- a/render-exam.js
+++ b/render-exam.js
@@ -227,7 +227,7 @@ function renderExam(questions) {
                                   <label class="followup-label" for="followup-input-${ans.id}">Ask a follow-up question</label>
                                   <div class="followup-input-row">
                                     <textarea id="followup-input-${ans.id}" class="followup-input" rows="2" placeholder="Ask about the feedback or awarded points..."></textarea>
-                                    <button type="button" class="followup-send-btn" data-answer-id="${ans.id}">Ask Gemini</button>
+                                    <button type="button" class="followup-send-btn" data-answer-id="${ans.id}">Send</button>
                                   </div>
                                 </div>`
                             : '';

--- a/render-exam.js
+++ b/render-exam.js
@@ -221,7 +221,7 @@ function renderExam(questions) {
                                   <div class="followup-history" aria-live="polite"></div>
                                   <span class="followup-status sr-only" aria-live="polite"></span>
                                   <div class="followup-input-row">
-                                    <textarea id="followup-input-${ans.id}" class="followup-input" rows="2" aria-label="Ask about the feedback or awarded points" placeholder="Ask about the feedback or awarded points..."></textarea>
+                                    <textarea id="followup-input-${ans.id}" class="followup-input" rows="1" aria-label="Ask about the feedback or awarded points" placeholder="Ask about the feedback or awarded points..."></textarea>
                                     <button type="button" class="followup-send-btn" data-answer-id="${ans.id}">Send</button>
                                   </div>
                                 </div>`

--- a/render-exam.js
+++ b/render-exam.js
@@ -229,7 +229,6 @@ function renderExam(questions) {
                                     <textarea id="followup-input-${ans.id}" class="followup-input" rows="2" placeholder="Ask about the feedback or awarded points..."></textarea>
                                     <button type="button" class="followup-send-btn" data-answer-id="${ans.id}">Ask Gemini</button>
                                   </div>
-                                  <p class="followup-footnote">Powered by Gemini 2.5 Pro</p>
                                 </div>`
                             : '';
                         return `

--- a/render-exam.js
+++ b/render-exam.js
@@ -218,15 +218,10 @@ function renderExam(questions) {
                                    data-context="${followupMeta ? encodeURIComponent(followupMeta.contextText) : ''}"
                                    data-question-label="${followupMeta ? encodeURIComponent(followupMeta.questionLabel) : ''}"
                                    data-sub-label="${followupMeta ? encodeURIComponent(followupMeta.subQuestionLabel) : ''}">
-                                  <div class="followup-header">
-                                    <span class="followup-title">Need more insight on this score?</span>
-                                    <span class="followup-status" aria-live="polite"></span>
-                                  </div>
-                                  <p class="followup-context-label"></p>
                                   <div class="followup-history" aria-live="polite"></div>
-                                  <label class="followup-label" for="followup-input-${ans.id}">Ask a follow-up question</label>
+                                  <span class="followup-status sr-only" aria-live="polite"></span>
                                   <div class="followup-input-row">
-                                    <textarea id="followup-input-${ans.id}" class="followup-input" rows="2" placeholder="Ask about the feedback or awarded points..."></textarea>
+                                    <textarea id="followup-input-${ans.id}" class="followup-input" rows="2" aria-label="Ask about the feedback or awarded points" placeholder="Ask about the feedback or awarded points..."></textarea>
                                     <button type="button" class="followup-send-btn" data-answer-id="${ans.id}">Send</button>
                                   </div>
                                 </div>`

--- a/student-answers.css
+++ b/student-answers.css
@@ -251,7 +251,7 @@ body.single-student-view .add-student-btn {
 }
 
 .followup-send-btn {
-    border: none;
+    background-color: var(--color-light-blue-two);
     border-radius: 10px;
     border: solid 2px var(--color-light-blue-three);
     font-weight: 600;

--- a/student-answers.css
+++ b/student-answers.css
@@ -163,6 +163,7 @@ body.single-student-view .add-student-btn {
     gap: 0.5rem;
     padding-right: 0.25rem;
     margin-bottom: 0.75rem;
+    border-radius: 10px;
 }
 
 .followup-message {

--- a/student-answers.css
+++ b/student-answers.css
@@ -321,12 +321,3 @@ body.single-student-view .add-student-btn {
     opacity: 0.6;
     box-shadow: none;
 }
-
-.followup-footnote {
-    margin-top: 0.75rem;
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: rgba(20, 17, 15, 0.5);
-    text-align: right;
-}

--- a/student-answers.css
+++ b/student-answers.css
@@ -117,3 +117,179 @@ body.single-student-view .student-answer-dropdown {
 body.single-student-view .add-student-btn {
     display: none !important;
 }
+
+/* === Feedback follow-up assistant === */
+.feedback-followup {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 12px;
+    background: linear-gradient(135deg, var(--color-lighter-blue), var(--color-light-blue-two));
+    border: 1px solid var(--color-background-border);
+    box-shadow: -3px 4px 0 rgba(51, 65, 149, 0.2);
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.feedback-followup.is-streaming {
+    box-shadow: -4px 6px 0 rgba(2, 161, 71, 0.35);
+    transform: translate(-1px, -1px);
+}
+
+.feedback-followup .followup-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.feedback-followup .followup-title {
+    font-weight: 700;
+    color: var(--color-blue-pastel);
+}
+
+.feedback-followup .followup-status {
+    font-size: 0.85rem;
+    color: var(--color-blue-pastel);
+}
+
+.feedback-followup .followup-status.is-error {
+    color: var(--color-danger);
+    font-weight: 600;
+}
+
+.feedback-followup .followup-context-label {
+    margin: 0.35rem 0 0.65rem;
+    font-size: 0.9rem;
+    color: var(--color-blue-pastel);
+}
+
+.feedback-followup .followup-context-label strong {
+    font-weight: 700;
+}
+
+.feedback-followup .followup-history {
+    max-height: 220px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding-right: 0.25rem;
+    margin-bottom: 0.75rem;
+}
+
+.followup-message {
+    display: flex;
+}
+
+.followup-message-user {
+    justify-content: flex-end;
+}
+
+.followup-message-model {
+    justify-content: flex-start;
+}
+
+.followup-bubble {
+    padding: 0.65rem 0.75rem;
+    border-radius: 12px;
+    background: var(--color-light-blue-three);
+    color: var(--color-text-dark);
+    font-size: 0.9rem;
+    line-height: 1.35;
+    max-width: 100%;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.followup-message-user .followup-bubble {
+    background: var(--color-green-pastel-light-three);
+    border: 1px solid rgba(2, 161, 71, 0.35);
+}
+
+.followup-message-model.is-error .followup-bubble {
+    border: 1px solid var(--color-danger);
+    background: rgba(227, 23, 10, 0.08);
+}
+
+.followup-message-model.is-streaming .followup-bubble {
+    position: relative;
+}
+
+.followup-message-model.is-streaming .followup-bubble::after {
+    content: '';
+    position: absolute;
+    inset: -1px;
+    border-radius: 12px;
+    border: 1px dashed rgba(51, 65, 149, 0.35);
+    animation: followupPulse 1.4s ease-in-out infinite;
+}
+
+@keyframes followupPulse {
+    0% { opacity: 0.2; }
+    50% { opacity: 0.6; }
+    100% { opacity: 0.2; }
+}
+
+.followup-label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.45rem;
+    color: var(--color-blue-pastel);
+}
+
+.followup-input-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: stretch;
+}
+
+.followup-input {
+    flex: 1 1 auto;
+    border-radius: 10px;
+    border: 1px solid var(--color-background-border-between);
+    padding: 0.6rem 0.75rem;
+    font-family: inherit;
+    font-size: 0.95rem;
+    resize: vertical;
+    min-height: 2.6rem;
+    transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.followup-input:focus {
+    outline: none;
+    border-color: var(--color-blue-pastel);
+    box-shadow: 0 0 0 3px rgba(51, 65, 149, 0.25);
+}
+
+.followup-send-btn {
+    background: var(--color-blue-pastel);
+    color: var(--color-text-light);
+    border: none;
+    border-radius: 10px;
+    padding: 0.6rem 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.followup-send-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 10px rgba(51, 65, 149, 0.25);
+}
+
+.followup-send-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    box-shadow: none;
+}
+
+.followup-footnote {
+    margin-top: 0.75rem;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(20, 17, 15, 0.5);
+    text-align: right;
+}

--- a/student-answers.css
+++ b/student-answers.css
@@ -126,33 +126,9 @@ body.single-student-view .add-student-btn {
     border: solid 2px var(--color-light-blue-three);
 }
 
-.feedback-followup .followup-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.feedback-followup .followup-title {
-    font-weight: 700;
-}
-
-.feedback-followup .followup-status {
-    font-size: 0.85rem;
-}
-
 .feedback-followup .followup-status.is-error {
     color: var(--color-danger);
     font-weight: 600;
-}
-
-.feedback-followup .followup-context-label {
-    margin: 0.35rem 0 0.65rem;
-    font-size: 0.85rem;
-}
-
-.feedback-followup .followup-context-label strong {
-    font-weight: 700;
 }
 
 .feedback-followup .followup-history {
@@ -255,10 +231,6 @@ body.single-student-view .add-student-btn {
     100% { opacity: 0.2; }
 }
 
-.followup-label {
-    display: hidden;
-}
-
 .followup-input-row {
     display: flex;
     gap: 0.5rem;
@@ -298,4 +270,16 @@ body.single-student-view .add-student-btn {
     cursor: not-allowed;
     opacity: 0.6;
     box-shadow: none;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }

--- a/student-answers.css
+++ b/student-answers.css
@@ -248,8 +248,6 @@ body.single-student-view .add-student-btn {
     font-family: inherit;
     font-size: 0.95rem;
     resize: vertical;
-    min-height: 2.6rem;
-    transition-duration: 0.3s;
 }
 
 .followup-input:focus {
@@ -263,7 +261,6 @@ body.single-student-view .add-student-btn {
     border: solid 2px var(--color-light-blue-three);
     font-weight: 600;
     cursor: pointer;
-    transition-duration: 0.3s;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/student-answers.css
+++ b/student-answers.css
@@ -137,6 +137,7 @@ body.single-student-view .add-student-btn {
     gap: 0.5rem;
     margin-bottom: 0.75rem;
     border-radius: 10px;
+    scrollbar-width: none;
 }
 
 .feedback-followup .followup-history::-webkit-scrollbar {

--- a/student-answers.css
+++ b/student-answers.css
@@ -194,15 +194,52 @@ body.single-student-view .add-student-btn {
     background: var(--color-light-blue-three);
     color: var(--color-text-dark);
     font-size: 0.9rem;
-    line-height: 1.35;
+    line-height: 1.45;
     max-width: 100%;
-    white-space: pre-wrap;
+    white-space: normal;
+    word-break: break-word;
+}
+
+.followup-bubble p {
+    margin: 0 0 0.5rem;
+}
+
+.followup-bubble p:last-child {
+    margin-bottom: 0;
+}
+
+.followup-bubble ul,
+.followup-bubble ol {
+    margin: 0.35rem 0 0.5rem 1.15rem;
+    padding-left: 0.75rem;
+}
+
+.followup-bubble li {
+    margin-bottom: 0.35rem;
+}
+
+.followup-bubble li:last-child {
+    margin-bottom: 0;
+}
+
+.followup-bubble code {
+    font-family: var(--font-family-monospace, 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace);
+    background: rgba(51, 65, 149, 0.12);
+    padding: 0.05rem 0.3rem;
+    border-radius: 6px;
+    font-size: 0.85rem;
+}
+
+.followup-bubble a {
+    color: var(--color-blue-pastel);
+    text-decoration: underline;
     word-break: break-word;
 }
 
 .followup-message-user .followup-bubble {
     background: var(--color-green-pastel-light-three);
     border: 1px solid rgba(2, 161, 71, 0.35);
+    white-space: pre-wrap;
 }
 
 .followup-message-model.is-error .followup-bubble {

--- a/student-answers.css
+++ b/student-answers.css
@@ -242,13 +242,18 @@ body.single-student-view .add-student-btn {
 .followup-input {
     flex: 1 1 auto;
     border-radius: 10px;
-    border: 1px solid var(--color-background-border-between);
+    border: 2px solid var(--color-light-blue-two);
     padding: 0.6rem 0.75rem;
     font-family: inherit;
     font-size: 0.95rem;
     resize: vertical;
     min-height: 2.6rem;
-    transition: border 0.2s ease, box-shadow 0.2s ease;
+    transition-duration: 0.3s;
+}
+
+.followup-input:focus {
+    outline: none;
+    background-color: var(--color-light-blue-three);
 }
 
 .followup-send-btn {

--- a/student-answers.css
+++ b/student-answers.css
@@ -259,6 +259,7 @@ body.single-student-view .add-student-btn {
     background-color: var(--color-light-blue-two);
     border-radius: 10px;
     border: solid 2px var(--color-light-blue-three);
+    padding: 0 0.8rem;
     font-weight: 600;
     cursor: pointer;
     display: flex;

--- a/student-answers.css
+++ b/student-answers.css
@@ -121,9 +121,7 @@ body.single-student-view .add-student-btn {
 /* === Feedback follow-up assistant === */
 .feedback-followup {
     margin-top: 1rem;
-    padding: 1rem;
     border-radius: 15px;
-    border: solid 2px var(--color-light-blue-three);
 }
 
 .feedback-followup .followup-status.is-error {
@@ -132,14 +130,17 @@ body.single-student-view .add-student-btn {
 }
 
 .feedback-followup .followup-history {
-    max-height: 220px;
+    max-height: 500px;
     overflow-y: auto;
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    padding-right: 0.25rem;
     margin-bottom: 0.75rem;
     border-radius: 10px;
+}
+
+.feedback-followup .followup-history::-webkit-scrollbar {
+  display: none;           /* Chrome, Safari */
 }
 
 .followup-message {

--- a/student-answers.css
+++ b/student-answers.css
@@ -241,8 +241,9 @@ body.single-student-view .add-student-btn {
 
 .followup-input {
     flex: 1 1 auto;
+    background-color: var(--color-light-blue-two);
     border-radius: 10px;
-    border: 2px solid var(--color-light-blue-two);
+    border: 2px solid var(--color-light-blue-three);
     padding: 0.6rem 0.75rem;
     font-family: inherit;
     font-size: 0.95rem;

--- a/student-answers.css
+++ b/student-answers.css
@@ -122,16 +122,8 @@ body.single-student-view .add-student-btn {
 .feedback-followup {
     margin-top: 1rem;
     padding: 1rem;
-    border-radius: 12px;
-    background: linear-gradient(135deg, var(--color-lighter-blue), var(--color-light-blue-two));
-    border: 1px solid var(--color-background-border);
-    box-shadow: -3px 4px 0 rgba(51, 65, 149, 0.2);
-    transition: box-shadow 0.2s ease, transform 0.2s ease;
-}
-
-.feedback-followup.is-streaming {
-    box-shadow: -4px 6px 0 rgba(2, 161, 71, 0.35);
-    transform: translate(-1px, -1px);
+    border-radius: 15px;
+    border: solid 2px var(--color-light-blue-three);
 }
 
 .feedback-followup .followup-header {
@@ -143,12 +135,10 @@ body.single-student-view .add-student-btn {
 
 .feedback-followup .followup-title {
     font-weight: 700;
-    color: var(--color-blue-pastel);
 }
 
 .feedback-followup .followup-status {
     font-size: 0.85rem;
-    color: var(--color-blue-pastel);
 }
 
 .feedback-followup .followup-status.is-error {
@@ -158,8 +148,7 @@ body.single-student-view .add-student-btn {
 
 .feedback-followup .followup-context-label {
     margin: 0.35rem 0 0.65rem;
-    font-size: 0.9rem;
-    color: var(--color-blue-pastel);
+    font-size: 0.85rem;
 }
 
 .feedback-followup .followup-context-label strong {
@@ -231,14 +220,13 @@ body.single-student-view .add-student-btn {
 }
 
 .followup-bubble a {
-    color: var(--color-blue-pastel);
+    color: var(--color-text-dark);
     text-decoration: underline;
     word-break: break-word;
 }
 
 .followup-message-user .followup-bubble {
-    background: var(--color-green-pastel-light-three);
-    border: 1px solid rgba(2, 161, 71, 0.35);
+    background: var(--color-light-blue-three);
     white-space: pre-wrap;
 }
 
@@ -256,7 +244,7 @@ body.single-student-view .add-student-btn {
     position: absolute;
     inset: -1px;
     border-radius: 12px;
-    border: 1px dashed rgba(51, 65, 149, 0.35);
+    border: 2px dashed rgba(51, 65, 149, 0.35);
     animation: followupPulse 1.4s ease-in-out infinite;
 }
 
@@ -267,10 +255,7 @@ body.single-student-view .add-student-btn {
 }
 
 .followup-label {
-    display: block;
-    font-weight: 600;
-    margin-bottom: 0.45rem;
-    color: var(--color-blue-pastel);
+    display: hidden;
 }
 
 .followup-input-row {
@@ -291,29 +276,21 @@ body.single-student-view .add-student-btn {
     transition: border 0.2s ease, box-shadow 0.2s ease;
 }
 
-.followup-input:focus {
-    outline: none;
-    border-color: var(--color-blue-pastel);
-    box-shadow: 0 0 0 3px rgba(51, 65, 149, 0.25);
-}
-
 .followup-send-btn {
-    background: var(--color-blue-pastel);
-    color: var(--color-text-light);
     border: none;
     border-radius: 10px;
-    padding: 0.6rem 1rem;
+    border: solid 2px var(--color-light-blue-three);
     font-weight: 600;
     cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+    transition-duration: 0.3s;
     display: flex;
     align-items: center;
     justify-content: center;
+    width: auto;
 }
 
 .followup-send-btn:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 10px rgba(51, 65, 149, 0.25);
+    background-color: var(--color-light-blue-three);
 }
 
 .followup-send-btn:disabled {


### PR DESCRIPTION
## Summary
- add follow-up context metadata and per-answer prompts so users can ask about awarded scores
- stream Gemini 2.5 Pro responses directly in a new feedback-followup client script with running chat history
- style the follow-up assistant UI and expose Gemini API key configuration for front-end use

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_6906600a93ec832eab3b7aa9e55baa1d