### PR TITLE
Simplify follow-up chat UI

### DIFF
--- a/render-exam.js
+++ b/render-exam.js
@@ -221,7 +221,7 @@ function renderExam(questions) {
                                   <div class="followup-history" aria-live="polite"></div>
                                   <span class="followup-status sr-only" aria-live="polite"></span>
                                   <div class="followup-input-row">
-                                    <textarea id="followup-input-${ans.id}" class="followup-input" rows="2" aria-label="Ask about the feedback or awarded points" placeholder="Ask about the feedback or awarded points..."></textarea>
+                                    <textarea id="followup-input-${ans.id}" class="followup-input" rows="1" aria-label="Ask about the feedback or awarded points" placeholder="Ask about the feedback or awarded points..."></textarea>
                                     <button type="button" class="followup-send-btn" data-answer-id="${ans.id}">Send</button>
                                   </div>
                                 </div>`

--- a/render-exam.js
+++ b/render-exam.js
@@ -218,15 +218,10 @@ function renderExam(questions) {
                                    data-context="${followupMeta ? encodeURIComponent(followupMeta.contextText) : ''}"
                                    data-question-label="${followupMeta ? encodeURIComponent(followupMeta.questionLabel) : ''}"
                                    data-sub-label="${followupMeta ? encodeURIComponent(followupMeta.subQuestionLabel) : ''}">
-                                  <div class="followup-header">
-                                    <span class="followup-title">Need more insight on this score?</span>
-                                    <span class="followup-status" aria-live="polite"></span>
-                                  </div>
-                                  <p class="followup-context-label"></p>
                                   <div class="followup-history" aria-live="polite"></div>
-                                  <label class="followup-label" for="followup-input-${ans.id}">Ask a follow-up question</label>
+                                  <span class="followup-status sr-only" aria-live="polite"></span>
                                   <div class="followup-input-row">
-                                    <textarea id="followup-input-${ans.id}" class="followup-input" rows="2" placeholder="Ask about the feedback or awarded points..."></textarea>
+                                    <textarea id="followup-input-${ans.id}" class="followup-input" rows="2" aria-label="Ask about the feedback or awarded points" placeholder="Ask about the feedback or awarded points..."></textarea>
                                     <button type="button" class="followup-send-btn" data-answer-id="${ans.id}">Send</button>
                                   </div>
                                 </div>`

--- a/student-answers.css
+++ b/student-answers.css
@@ -251,7 +251,7 @@ body.single-student-view .add-student-btn {
 }
 
 .followup-send-btn {
-    border: none;
+    background-color: var(--color-light-blue-two);
     border-radius: 10px;
     border: solid 2px var(--color-light-blue-three);
     font-weight: 600;

--- a/student-answers.css
+++ b/student-answers.css
@@ -126,33 +126,9 @@ body.single-student-view .add-student-btn {
     border: solid 2px var(--color-light-blue-three);
 }
 
-.feedback-followup .followup-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.feedback-followup .followup-title {
-    font-weight: 700;
-}
-
-.feedback-followup .followup-status {
-    font-size: 0.85rem;
-}
-
 .feedback-followup .followup-status.is-error {
     color: var(--color-danger);
     font-weight: 600;
-}
-
-.feedback-followup .followup-context-label {
-    margin: 0.35rem 0 0.65rem;
-    font-size: 0.85rem;
-}
-
-.feedback-followup .followup-context-label strong {
-    font-weight: 700;
 }
 
 .feedback-followup .followup-history {
@@ -255,10 +231,6 @@ body.single-student-view .add-student-btn {
     100% { opacity: 0.2; }
 }
 
-.followup-label {
-    display: hidden;
-}
-
 .followup-input-row {
     display: flex;
     gap: 0.5rem;
@@ -298,4 +270,16 @@ body.single-student-view .add-student-btn {
     cursor: not-allowed;
     opacity: 0.6;
     box-shadow: none;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }

--- a/student-answers.css
+++ b/student-answers.css
@@ -248,8 +248,6 @@ body.single-student-view .add-student-btn {
     font-family: inherit;
     font-size: 0.95rem;
     resize: vertical;
-    min-height: 2.6rem;
-    transition-duration: 0.3s;
 }
 
 .followup-input:focus {
@@ -263,7 +261,6 @@ body.single-student-view .add-student-btn {
     border: solid 2px var(--color-light-blue-three);
     font-weight: 600;
     cursor: pointer;
-    transition-duration: 0.3s;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/student-answers.css
+++ b/student-answers.css
@@ -137,6 +137,7 @@ body.single-student-view .add-student-btn {
     gap: 0.5rem;
     margin-bottom: 0.75rem;
     border-radius: 10px;
+    scrollbar-width: none;
 }
 
 .feedback-followup .followup-history::-webkit-scrollbar {

--- a/student-answers.css
+++ b/student-answers.css
@@ -242,13 +242,18 @@ body.single-student-view .add-student-btn {
 .followup-input {
     flex: 1 1 auto;
     border-radius: 10px;
-    border: 1px solid var(--color-background-border-between);
+    border: 2px solid var(--color-light-blue-two);
     padding: 0.6rem 0.75rem;
     font-family: inherit;
     font-size: 0.95rem;
     resize: vertical;
     min-height: 2.6rem;
-    transition: border 0.2s ease, box-shadow 0.2s ease;
+    transition-duration: 0.3s;
+}
+
+.followup-input:focus {
+    outline: none;
+    background-color: var(--color-light-blue-three);
 }
 
 .followup-send-btn {

--- a/student-answers.css
+++ b/student-answers.css
@@ -259,6 +259,7 @@ body.single-student-view .add-student-btn {
     background-color: var(--color-light-blue-two);
     border-radius: 10px;
     border: solid 2px var(--color-light-blue-three);
+    padding: 0 0.8rem;
     font-weight: 600;
     cursor: pointer;
     display: flex;

--- a/student-answers.css
+++ b/student-answers.css
@@ -121,9 +121,7 @@ body.single-student-view .add-student-btn {
 /* === Feedback follow-up assistant === */
 .feedback-followup {
     margin-top: 1rem;
-    padding: 1rem;
     border-radius: 15px;
-    border: solid 2px var(--color-light-blue-three);
 }
 
 .feedback-followup .followup-status.is-error {
@@ -132,14 +130,17 @@ body.single-student-view .add-student-btn {
 }
 
 .feedback-followup .followup-history {
-    max-height: 220px;
+    max-height: 500px;
     overflow-y: auto;
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    padding-right: 0.25rem;
     margin-bottom: 0.75rem;
     border-radius: 10px;
+}
+
+.feedback-followup .followup-history::-webkit-scrollbar {
+  display: none;           /* Chrome, Safari */
 }
 
 .followup-message {

--- a/student-answers.css
+++ b/student-answers.css
@@ -241,8 +241,9 @@ body.single-student-view .add-student-btn {
 
 .followup-input {
     flex: 1 1 auto;
+    background-color: var(--color-light-blue-two);
     border-radius: 10px;
-    border: 2px solid var(--color-light-blue-two);
+    border: 2px solid var(--color-light-blue-three);
     padding: 0.6rem 0.75rem;
     font-family: inherit;
     font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- remove follow-up assistant header, context label, and prompt text from the rendered exam UI
- hide status updates behind a screen-reader-only element while surfacing error statuses inside the chat history
- clean up follow-up styles and add a reusable sr-only utility class

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69068a9527e8832ebf8e10cc210bd399